### PR TITLE
fix: 书架设置-显示视图功能不生效

### DIFF
--- a/web/src/plugins/vuex.js
+++ b/web/src/plugins/vuex.js
@@ -48,7 +48,7 @@ export default new Vuex.Store({
     userList: [].concat(defaultNS),
     userNS: "default",
     showManagerMode: false,
-    version: "v3.2.14-05250935",
+    version: "v4.0.0",
     filterRules: [],
     speechVoiceConfig: { ...settings.speechVoiceConfig },
     safeArea: {

--- a/web/src/views/Index.vue
+++ b/web/src/views/Index.vue
@@ -671,7 +671,7 @@
         @touchend="handleTouchEnd"
         @scroll="scrollHandler"
       >
-        <div class="wrapper">
+        <div class="wrapper" :style="shelfViewStyle">
           <div
             class="book"
             :style="showNavigation ? { minWidth: '360px !important' } : {}"
@@ -3324,6 +3324,20 @@ export default {
       "dialogContentHeight",
       "popupWidth"
     ]),
+    shelfViewStyle() {
+      const viewCate = this.$store.state.shelfConfig.viewCate;
+      if (viewCate === "list") {
+        return { gridTemplateColumns: "1fr" };
+      }
+      if (viewCate && viewCate.startsWith("column-")) {
+        const n = viewCate.replace("column-", "");
+        if (n === "100" || n === "150" || n === "200") {
+          return { gridTemplateColumns: `repeat(auto-fill, ${n}px)` };
+        }
+        return { gridTemplateColumns: `repeat(${n}, 1fr)` };
+      }
+      return {};
+    },
     config() {
       return this.$store.getters.config;
     },


### PR DESCRIPTION
## 问题

书架设置中的「显示视图」（列表/网格3列/4列/5列/6列/网格小中大）不生效——书架始终以固定 auto-fill 380px 网格渲染， 从未被消费。

## 根因

与 reader-pro 3.2.14 JAR 前端产物对比：JAR 根据 viewCate 渲染 BookList（列表）/BookColumn（网格 N 列），PR 的 Index.vue 书架渲染丢失了该逻辑（字符串差集验证：JAR 产物含 viewCate 渲染分支，PR 源码无）。

## 修复

Index.vue 书架 .wrapper 增加 shelfViewStyle 计算属性，8 种视图全部接入：
- list → 单列 1fr
- column-3/4/5/6 → repeat(N, 1fr)
- column-100/150/200 → repeat(auto-fill, Npx)

另：版本号显示改为 v4.0.0（新版本体系起点）。

## 验证

- npm run build 通过
- 产物含 viewCate 渲染分支（与 JAR 对齐）