### PR TITLE
ci: latest 标签 + Release 发布

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,33 @@ permissions:
   packages: write
 
 jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+      - name: Build jar
+        run: ./gradlew -b cli.gradle assemble -x test
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/libs/*.jar
+          generate_release_notes: true
+
+  build-and-push:
+
+jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +68,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=sha
 
       - name: Build and push


### PR DESCRIPTION
## 变更

发版基础设施（docker-publish workflow）：

1. **latest 标签**：tag 推送（v*）时镜像额外打 ghcr.io/warpdotsys/reader-dev:latest，保证「冒号后无版本号的默认包」始终是最新发版
2. **GitHub Releases**：新增 release job——v* tag 触发时用 cli.gradle 构建 jar 并发布到 GitHub Releases（含自动生成 release notes）

## 验证

- PR check（build job）通过即合并
- 合并后打 tag v4.0.0 实测：ghcr 出现 v4.0.0 + latest，Releases 出现 v4.0.0 附 jar