### PR TITLE
fix: Release 产物 jar 版本号 4.0.0

### DIFF
--- a/cli.gradle
+++ b/cli.gradle
@@ -17,7 +17,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'kotlin'
 
 group = 'com.htmake'
-version = '2.5.4'
+version = '4.0.0'
 sourceCompatibility = '1.8'
 
 repositories {


### PR DESCRIPTION
## 问题

v4.0.0 Release 的 jar 产物名为 reader-dev-2.5.4.jar——cli.gradle 的 version 是 fork 遗留的 2.5.4，与版本体系不一致。

## 修复

cli.gradle version 2.5.4 → 4.0.0。此后 Release 产物为 reader-dev-4.0.0.jar。

## 验证

- PR check 构建通过后合并
- 下次发版（v4.0.1）时 Release 产物名正确