### PR TITLE
release: 版本号同步 4.0.1

### DIFF
--- a/cli.gradle
+++ b/cli.gradle
@@ -17,7 +17,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'kotlin'
 
 group = 'com.htmake'
-version = '4.0.0'
+version = '4.0.1'
 sourceCompatibility = '1.8'
 
 repositories {

--- a/web/src/plugins/vuex.js
+++ b/web/src/plugins/vuex.js
@@ -48,7 +48,7 @@ export default new Vuex.Store({
     userList: [].concat(defaultNS),
     userNS: "default",
     showManagerMode: false,
-    version: "v4.0.0",
+    version: "v4.0.1",
     filterRules: [],
     speechVoiceConfig: { ...settings.speechVoiceConfig },
     safeArea: {


### PR DESCRIPTION
## 变更

v4.0.1 发版前的版本号同步：
- cli.gradle version → 4.0.1（Release jar 名）
- web/src/plugins/vuex.js 显示版本 → v4.0.1

## 流程

合并后打 tag v4.0.1 触发 docker-publish（ghcr 镜像 v4.0.1 + latest + Release 附 jar）。