### PR TITLE
fix: 显示视图溢出/新书排序/封面下载

### DIFF
--- a/src/main/java/com/htmake/reader/api/controller/BookController.kt
+++ b/src/main/java/com/htmake/reader/api/controller/BookController.kt
@@ -234,7 +234,10 @@ class BookController(coroutineContext: CoroutineContext): BaseController(corouti
             logger.info("get cover error: {}", exception.message)
             context.response().setStatusCode(404).end()
         }) {
-            webClient.getAbs(coverUrl).timeout(3000).send {
+            webClient.getAbs(coverUrl)
+                .putHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                .putHeader("Referer", coverUrl.substringBeforeLast("/"))
+                .timeout(10000).send {
                 var bodyBytes = it.result()?.bodyAsBuffer()?.getBytes()
                 if (bodyBytes != null) {
                     var res = context.response().putHeader("Cache-Control", "86400")
@@ -3493,6 +3496,10 @@ class BookController(coroutineContext: CoroutineContext): BaseController(corouti
             }
         }
         book.isInShelf = true
+        if (existIndex < 0) {
+            // 新书加入书架时更新阅读时间，使其按 durChapterTime 排在最前
+            book.durChapterTime = System.currentTimeMillis()
+        }
         if (existIndex >= 0) {
             var bookList = bookshelf.getList()
             var existBook = bookshelf.getJsonObject(existIndex).mapTo(Book::class.java)

--- a/web/src/views/Index.vue
+++ b/web/src/views/Index.vue
@@ -671,7 +671,7 @@
         @touchend="handleTouchEnd"
         @scroll="scrollHandler"
       >
-        <div class="wrapper" :style="shelfViewStyle">
+        <div class="wrapper" :style="shelfViewStyle" :class="shelfViewClass">
           <div
             class="book"
             :style="showNavigation ? { minWidth: '360px !important' } : {}"
@@ -3338,6 +3338,16 @@ export default {
       }
       return {};
     },
+    shelfViewClass() {
+      const viewCate = this.$store.state.shelfConfig.viewCate;
+      if (viewCate === "list") {
+        return "list-mode";
+      }
+      if (viewCate && viewCate.startsWith("column-")) {
+        return "column-mode";
+      }
+      return "";
+    },
     config() {
       return this.$store.getters.config;
     },
@@ -3834,6 +3844,24 @@ export default {
         grid-template-columns: repeat(auto-fill, 380px);
         justify-content: space-around;
         grid-gap: 10px;
+
+        &.list-mode {
+          grid-template-columns: 1fr;
+          justify-content: initial;
+
+          .book {
+            width: auto;
+          }
+        }
+
+        &.column-mode {
+          justify-content: initial;
+
+          .book {
+            width: auto;
+            min-width: 0;
+          }
+        }
 
         .book {
           user-select: none;


### PR DESCRIPTION
## 问题（v4.0.1 实机测试）

1. 显示视图 8 种：列模式右端出屏幕（.book 固定 360px 宽，网格列更窄时溢出）
2. 加入书架后新书找不到：saveBookToShelf 新书分支未设 durChapterTime，前端按 durChapterTime 降序排到末尾
3. 搜索封面部分失败：/reader3/cover 代理下载 timeout 3s 且无请求头，慢源/防盗链源失败

## 修复

1. 书架 .wrapper 增加 list-mode/column-mode：列模式 .book 宽度自适应（min-width:0），列表模式全宽
2. 新书分支 durChapterTime = System.currentTimeMillis()（排最前；与 JAR 原行为的有意偏差，符合预期体验）
3. getBookCover 下载加 UA + Referer 头，超时 3s → 10s

## 验证

- 编译 + web 构建通过
- 合并后发版 v4.0.2 部署实机复测