### PR TITLE
fix(web): 组件对齐 JAR 第一批（App.vue 接入/用户管理/授权管理）

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -84,6 +84,22 @@
 
     <BookGroup v-model="showBookGroupDialog" :isSet="isSetBookGroup" />
 
+    <HttpTTS v-model="showHttpTTSDialog" />
+
+    <FileManager
+      v-model="showFileManagerDialog"
+      :home="fileManagerHome"
+      :title="fileManagerTitle"
+    />
+
+    <License v-model="showLicenseDialog" />
+
+    <BookConfig v-model="showBookConfigDialog" />
+
+    <RemoteBookSourceSub v-model="showRemoteBookSourceSubDialog" />
+
+    <ActiveLicense v-model="showActiveLicenseDialog" />
+
     <RssSourceList v-model="showRssSourceListDialog" />
     <RssArticleList v-model="showRssArticleListDialog" :rssSource="rssSource" />
     <RssArticle
@@ -118,6 +134,12 @@ import BookInfo from "./components/BookInfo.vue";
 import UserManage from "./components/UserManage.vue";
 import AddUser from "./components/AddUser.vue";
 import BookGroup from "./components/BookGroup.vue";
+import HttpTTS from "./components/HttpTTS.vue";
+import FileManager from "./components/FileManager.vue";
+import License from "./components/License.vue";
+import BookConfig from "./components/BookConfig.vue";
+import RemoteBookSourceSub from "./components/RemoteBookSourceSub.vue";
+import ActiveLicense from "./components/ActiveLicense.vue";
 import RssSourceList from "./components/RssSourceList.vue";
 import RssArticleList from "./components/RssArticleList.vue";
 import RssArticle from "./components/RssArticle.vue";
@@ -197,6 +219,12 @@ export default {
     UserManage,
     AddUser,
     BookGroup,
+    HttpTTS,
+    FileManager,
+    License,
+    BookConfig,
+    RemoteBookSourceSub,
+    ActiveLicense,
     RssSourceList,
     RssArticleList,
     RssArticle,
@@ -233,6 +261,15 @@ export default {
 
       showBookGroupDialog: false,
       isSetBookGroup: false,
+
+      showHttpTTSDialog: false,
+      showFileManagerDialog: false,
+      fileManagerHome: "",
+      fileManagerTitle: "文件管理",
+      showLicenseDialog: false,
+      showBookConfigDialog: false,
+      showRemoteBookSourceSubDialog: false,
+      showActiveLicenseDialog: false,
 
       showRssSourceListDialog: false,
       showRssArticleListDialog: false,
@@ -348,6 +385,28 @@ export default {
     });
     eventBus.$on("showUserManageDialog", () => {
       this.showUserManageDialog = true;
+    });
+    eventBus.$on("showHttpTTSDialog", () => {
+      this.showHttpTTSDialog = true;
+    });
+    eventBus.$on("showFileManagerDialog", data => {
+      this.showFileManagerDialog = true;
+      if (data) {
+        this.fileManagerHome = data.home || "";
+        this.fileManagerTitle = data.title || "文件管理";
+      }
+    });
+    eventBus.$on("showLicenseDialog", () => {
+      this.showLicenseDialog = true;
+    });
+    eventBus.$on("showBookConfigDialog", () => {
+      this.showBookConfigDialog = true;
+    });
+    eventBus.$on("showRemoteBookSourceSubDialog", () => {
+      this.showRemoteBookSourceSubDialog = true;
+    });
+    eventBus.$on("showActiveLicenseDialog", () => {
+      this.showActiveLicenseDialog = true;
     });
     eventBus.$on("showAddUserDialog", () => {
       this.showAddUserDialog = true;

--- a/web/src/components/License.vue
+++ b/web/src/components/License.vue
@@ -101,6 +101,133 @@ export default {
         }
       );
     },
+    async importLicense() {
+      const res = await this.$prompt("请输入密钥", "更新密钥", {
+        inputValue: "",
+        confirmButtonText: "确定",
+        cancelButtonText: "取消",
+        inputValidator(v) {
+          if (!v) {
+            return "密钥不能为空";
+          }
+          return true;
+        }
+      }).catch(() => {
+        return false;
+      });
+      if (!res) {
+        return;
+      }
+      return this.comfirmImport(res.value);
+    },
+    async comfirmImport(key) {
+      const res = await this.$confirm("确认要更新密钥吗?", "提示", {
+        confirmButtonText: "确定",
+        cancelButtonText: "取消",
+        type: "warning"
+      }).catch(() => {
+        return false;
+      });
+      if (!res) {
+        return;
+      }
+      Axios.post(this.api + "/importLicense", {
+        content: key
+      }).then(
+        res => {
+          if (res.data.isSuccess) {
+            this.$message.success("更新密钥成功");
+            this.license = res.data.data.license;
+          }
+        },
+        error => {
+          this.$message.error(
+            "更新密钥失败 " + (error && error.toString())
+          );
+        }
+      );
+    },
+    async supplyLicense() {
+      const res = await this.$prompt(
+        "请输入邮箱进行验证，每个邮箱仅限试用一次，有效期7天",
+        "验证邮箱",
+        {
+          inputValue: "",
+          confirmButtonText: "确定",
+          cancelButtonText: "取消",
+          inputValidator(v) {
+            if (!v) {
+              return "邮箱不能为空";
+            }
+            return true;
+          }
+        }
+      ).catch(() => {
+        return false;
+      });
+      if (!res) {
+        return;
+      }
+      const email = res.value;
+      if (
+        !email.match(
+          /@(163|126|qq|yahoo|sina|sohu|yeah|139|189|21cn|outlook|gmail|icloud).com$/
+        )
+      ) {
+        this.$message.error(
+          "仅支持163|126|qq|yahoo|sina|sohu|yeah|139|189|21cn|outlook|gmail|icloud等邮箱"
+        );
+        return;
+      }
+      Axios.post(this.api + "/sendCodeToEmail", {
+        email
+      }).then(
+        res => {
+          if (res.data.isSuccess) {
+            this.showVerifyCodePrompt(email);
+          }
+        },
+        error => {
+          this.$message.error(
+            "发送验证码失败 " + (error && error.toString())
+          );
+        }
+      );
+    },
+    async showVerifyCodePrompt(email) {
+      const res = await this.$prompt("请输入验证码", "验证邮箱", {
+        inputValue: "",
+        confirmButtonText: "确定",
+        cancelButtonText: "取消",
+        inputValidator(v) {
+          if (!v) {
+            return "验证码不能为空";
+          }
+          return true;
+        }
+      }).catch(() => {
+        return false;
+      });
+      if (!res) {
+        return;
+      }
+      Axios.post(this.api + "/supplyLicense", {
+        email,
+        code: res.value
+      }).then(
+        res => {
+          if (res.data.isSuccess) {
+            this.$message.success("申请试用密钥成功，有效期7天，请谨慎更新");
+            this.license = res.data.data.license;
+          }
+        },
+        error => {
+          this.$message.error(
+            "申请试用失败 " + (error && error.toString())
+          );
+        }
+      );
+    },
     async supplyLicense() {
       const emailRes = await this.$prompt(
         "请输入邮箱进行验证，每个邮箱仅限试用一次，有效期7天",

--- a/web/src/components/UserManage.vue
+++ b/web/src/components/UserManage.vue
@@ -17,13 +17,17 @@
         <span class="float-right span-btn" @click="showAddUserDialog()"
           >新增</span
         >
+        <span class="float-right span-btn" @click="clearInactiveUser()"
+          >清理不活跃用户</span
+        >
       </span>
     </div>
     <div class="source-container table-container">
       <el-table
-        :data="userList"
+        :data="showList"
         :height="dialogContentHeight"
         @selection-change="manageUserSelection = $event"
+        @sort-change="sortChange"
       >
         <el-table-column
           type="selection"
@@ -36,6 +40,7 @@
           property="username"
           label="用户名"
           min-width="100"
+          sortable
           :fixed="$store.state.miniInterface"
         ></el-table-column>
         <el-table-column
@@ -82,8 +87,11 @@
             </el-switch>
           </template>
         </el-table-column>
-        <el-table-column label="操作" width="100px">
+        <el-table-column label="操作" width="120px">
           <template slot-scope="scope">
+            <el-button type="text" @click="editUser(scope.row)"
+              >编辑</el-button
+            >
             <el-button type="text" @click="resetPassword(scope.row)"
               >重置密码</el-button
             >
@@ -93,6 +101,16 @@
           </template>
         </el-table-column>
       </el-table>
+      <el-pagination
+        @current-change="pagination.page = $event"
+        @size-change="pagination.size = $event"
+        :current-page="pagination.page"
+        :page-size="pagination.size"
+        :page-sizes="[25, 50, 100]"
+        layout="total, sizes, prev, pager, next"
+        :total="filterList.length"
+      >
+      </el-pagination>
     </div>
     <div slot="footer" class="dialog-footer">
       <el-button
@@ -129,7 +147,16 @@ export default {
   name: "UserManage",
   data() {
     return {
-      manageUserSelection: []
+      manageUserSelection: [],
+      search: "",
+      pagination: {
+        page: 1,
+        size: 25
+      },
+      sortable: {
+        prop: "",
+        order: null
+      }
     };
   },
   props: ["show"],
@@ -142,6 +169,37 @@ export default {
       set(val) {
         this.$store.commit("setUserList", val);
       }
+    },
+    filterList() {
+      return this.userList.filter(
+        v =>
+          v.userNS !== "default" &&
+          (!this.search ||
+            v.username.toLowerCase().includes(this.search.toLowerCase()))
+      );
+    },
+    sortList() {
+      if (!this.sortable.prop || !this.sortable.order) {
+        return this.filterList;
+      }
+      const list = [].concat(this.filterList);
+      return list.sort((a, b) => {
+        if (this.sortable.order !== "ascending") {
+          const t = a;
+          a = b;
+          b = t;
+        }
+        return a[this.sortable.prop] > b[this.sortable.prop] ? 1 : a[this.sortable.prop] < b[this.sortable.prop] ? -1 : 0;
+      });
+    },
+    showList() {
+      const start = (this.pagination.page - 1) * this.pagination.size;
+      return start > this.sortList.length
+        ? []
+        : this.sortList.slice(
+            start,
+            Math.min(start + this.pagination.size, this.sortList.length)
+          );
     }
   },
   watch: {
@@ -157,6 +215,58 @@ export default {
     },
     showAddUserDialog() {
       eventBus.$emit("showAddUserDialog");
+    },
+    editUser(user) {
+      eventBus.$emit("showAddUserDialog", user);
+    },
+    sortChange({ prop, order }) {
+      this.sortable = { prop, order };
+    },
+    async clearInactiveUser() {
+      const res = await this.$prompt(
+        "请输入需要清理的未登录天数",
+        "清理不活跃用户",
+        {
+          inputValue: 31,
+          confirmButtonText: "确定",
+          cancelButtonText: "取消",
+          inputValidator(v) {
+            if (!v) {
+              return "天数不能为空";
+            }
+            return !isNaN(parseInt(v)) || "天数必须是数字";
+          }
+        }
+      ).catch(() => {
+        return false;
+      });
+      if (!res || !res.value) {
+        return;
+      }
+      Axios.post(
+        this.api + "/clearInactiveUsers",
+        {
+          inactiveDay: parseInt(res.value)
+        },
+        {
+          timeout: 0
+        }
+      ).then(
+        res => {
+          if (res.data.isSuccess) {
+            this.$message.success("清理不活跃用户成功");
+            this.userList = res.data.data.map(v => ({
+              ...v,
+              userNS: v.username
+            }));
+          }
+        },
+        error => {
+          this.$message.error(
+            "清理不活跃用户失败 " + (error && error.toString())
+          );
+        }
+      );
     },
     formatTableField(row, column, cellValue) {
       switch (column.property) {


### PR DESCRIPTION
## 背景

对 reader-pro 3.2.14 JAR 的 web 产物做模块级逆向对比：PR 创建的多个组件从未接入（App.vue 未注册），大量功能缺失。本批修复 3 个：

## 修复

1. **App.vue**：HttpTTS/FileManager/License/BookConfig/RemoteBookSourceSub/ActiveLicense 补齐注册 + 对话框状态 + eventBus 监听（对齐 JAR 的 23 个监听）
2. **UserManage.vue**：新增清理不活跃用户（POST /clearInactiveUsers）、编辑用户、表格排序 + 分页
3. **License.vue**：新增更新密钥（POST /importLicense）、申请试用（邮箱白名单校验 + sendCodeToEmail + POST /supplyLicense）

## 验证

- 构建通过；app bundle 与 JAR 的中文差异 114 → 51
- 合并后发版部署实机验证