### PR TITLE
fix(web): 组件对齐 JAR 第二批（书籍管理/文案）

### DIFF
--- a/web/src/components/BookManage.vue
+++ b/web/src/components/BookManage.vue
@@ -102,6 +102,11 @@
               <el-dropdown-menu slot="dropdown">
                 <el-dropdown-item
                   v-if="scope.row.origin !== 'loc_book'"
+                  command="cacheBookOnServer"
+                  >服务器缓存</el-dropdown-item
+                >
+                <el-dropdown-item
+                  v-if="scope.row.origin !== 'loc_book'"
                   command="cacheBookSSE"
                   >缓存到服务器</el-dropdown-item
                 >
@@ -376,6 +381,23 @@ export default {
     },
     cacheBook(book, command) {
       this[command](book);
+    },
+    cacheBookOnServer(book) {
+      const books = Array.isArray(book) ? book : [book];
+      Axios.post(this.api + "/cacheBookOnServer", {
+        bookUrlList: books.map(v => v.bookUrl)
+      }).then(
+        res => {
+          if (res.data.isSuccess) {
+            this.$message.success("提交缓存任务成功");
+          }
+        },
+        error => {
+          this.$message.error(
+            "提交缓存任务失败 " + (error && error.toString())
+          );
+        }
+      );
     },
     async cacheBookSSE(book) {
       const tryClose = () => {

--- a/web/src/views/Index.vue
+++ b/web/src/views/Index.vue
@@ -2411,7 +2411,7 @@ export default {
         return;
       }
       const res = await this.$confirm(
-        "确认要备份当前终端的阅读配置、书架设置、搜索设置、自定义配置方案吗?",
+        "确认要备份当前终端的阅读配置、书架设置、搜索设置、自定义配置方案、朗读配置吗?",
         "提示"
       ).catch(() => {
         return false;
@@ -2445,7 +2445,7 @@ export default {
         return;
       }
       const res = await this.$confirm(
-        "确认要从备份文件中恢复当前终端的阅读配置、书架设置、搜索设置、自定义配置方案吗?",
+        "确认要从备份文件中恢复当前终端的阅读配置、书架设置、搜索设置、自定义配置方案、朗读方案吗?",
         "提示"
       ).catch(() => {
         return false;


### PR DESCRIPTION
## 修复

1. BookManage：新增 cacheBookOnServer（服务器缓存命令）——POST /cacheBookOnServer {bookUrlList}，提交缓存任务成功/失败提示
2. Index：备份/恢复确认文案补齐「朗读配置/朗读方案」（对齐 JAR 文案）

## 验证

- 构建通过；app bundle 中文差异 51 → 48（剩余为按钮空格/列 label 等文案细节）