### PR TITLE
feat(web): Edge TTS 完整语音库（147 方言/441 语音）

### DIFF
--- a/web/src/plugins/ttsVoices.js
+++ b/web/src/plugins/ttsVoices.js
@@ -1,0 +1,1768 @@
+// Edge TTS voice library (from reader-pro 3.2.14 JAR)
+export const ttsVoiceDialects = {
+  "中文（上海话，简体）": {
+    "ShortName": [
+      "wuu-CN-XiaotongNeural",
+      "wuu-CN-YunzheNeural"
+    ],
+    "LocalName": [
+      "晓彤",
+      "云哲"
+    ]
+  },
+  "中文（广东话，简体）": {
+    "ShortName": [
+      "yue-CN-XiaoMinNeural",
+      "yue-CN-YunSongNeural"
+    ],
+    "LocalName": [
+      "晓敏",
+      "云松"
+    ]
+  },
+  "中文（普通话，简体）": {
+    "ShortName": [
+      "zh-CN-XiaoxiaoNeural",
+      "zh-CN-YunyangNeural",
+      "zh-CN-YunxiNeural",
+      "zh-CN-XiaoyiNeural",
+      "zh-CN-YunjianNeural",
+      "zh-CN-YunxiaNeural"
+    ],
+    "LocalName": [
+      "晓晓（女 - 年轻人）",
+      "云扬（男 - 年轻人）",
+      "云希（男 - 年轻人 - 抖音热门）",
+      "晓伊（女 - 儿童）",
+      "云健（男 - 中年人）",
+      "云夏（男 - 儿童）"
+    ]
+  },
+  "中文（河南话，简体）": {
+    "ShortName": [
+      "zh-CN-henan-YundengNeural"
+    ],
+    "LocalName": [
+      "云登"
+    ]
+  },
+  "中文（东北话，简体）": {
+    "ShortName": [
+      "zh-CN-liaoning-XiaobeiNeural"
+    ],
+    "LocalName": [
+      "晓北"
+    ]
+  },
+  "中文（陕西话，简体）": {
+    "ShortName": [
+      "zh-CN-shaanxi-XiaoniNeural"
+    ],
+    "LocalName": [
+      "晓妮"
+    ]
+  },
+  "中文（山东话，简体）": {
+    "ShortName": [
+      "zh-CN-shandong-YunxiangNeural"
+    ],
+    "LocalName": [
+      "云翔"
+    ]
+  },
+  "中文（四川话，简体）": {
+    "ShortName": [
+      "zh-CN-sichuan-YunxiNeural"
+    ],
+    "LocalName": [
+      "云希"
+    ]
+  },
+  "中文（香港话，繁体）": {
+    "ShortName": [
+      "zh-HK-HiuMaanNeural",
+      "zh-HK-HiuGaaiNeural",
+      "zh-HK-WanLungNeural"
+    ],
+    "LocalName": [
+      "曉曼",
+      "曉佳",
+      "雲龍"
+    ]
+  },
+  "中文（台湾话，繁体）": {
+    "ShortName": [
+      "zh-TW-HsiaoChenNeural",
+      "zh-TW-HsiaoYuNeural",
+      "zh-TW-YunJheNeural"
+    ],
+    "LocalName": [
+      "曉臻",
+      "曉雨",
+      "雲哲"
+    ]
+  },
+  "English (Australia)": {
+    "ShortName": [
+      "en-AU-NatashaNeural",
+      "en-AU-WilliamNeural",
+      "en-AU-AnnetteNeural",
+      "en-AU-CarlyNeural",
+      "en-AU-DarrenNeural",
+      "en-AU-DuncanNeural",
+      "en-AU-ElsieNeural",
+      "en-AU-FreyaNeural",
+      "en-AU-JoanneNeural",
+      "en-AU-KenNeural",
+      "en-AU-KimNeural",
+      "en-AU-NeilNeural",
+      "en-AU-TimNeural",
+      "en-AU-TinaNeural"
+    ],
+    "LocalName": [
+      "Natasha",
+      "William",
+      "Annette",
+      "Carly",
+      "Darren",
+      "Duncan",
+      "Elsie",
+      "Freya",
+      "Joanne",
+      "Ken",
+      "Kim",
+      "Neil",
+      "Tim",
+      "Tina"
+    ]
+  },
+  "English (Canada)": {
+    "ShortName": [
+      "en-CA-ClaraNeural",
+      "en-CA-LiamNeural"
+    ],
+    "LocalName": [
+      "Clara",
+      "Liam"
+    ]
+  },
+  "English (United Kingdom)": {
+    "ShortName": [
+      "en-GB-LibbyNeural",
+      "en-GB-AbbiNeural",
+      "en-GB-AlfieNeural",
+      "en-GB-BellaNeural",
+      "en-GB-ElliotNeural",
+      "en-GB-EthanNeural",
+      "en-GB-HollieNeural",
+      "en-GB-MaisieNeural",
+      "en-GB-NoahNeural",
+      "en-GB-OliverNeural",
+      "en-GB-OliviaNeural",
+      "en-GB-ThomasNeural",
+      "en-GB-RyanNeural",
+      "en-GB-SoniaNeural",
+      "en-GB-MiaNeural"
+    ],
+    "LocalName": [
+      "Libby",
+      "Abbi",
+      "Alfie",
+      "Bella",
+      "Elliot",
+      "Ethan",
+      "Hollie",
+      "Maisie",
+      "Noah",
+      "Oliver",
+      "Olivia",
+      "Thomas",
+      "Ryan",
+      "Sonia",
+      "Mia"
+    ]
+  },
+  "English (Hongkong)": {
+    "ShortName": [
+      "en-HK-SamNeural",
+      "en-HK-YanNeural"
+    ],
+    "LocalName": [
+      "Sam",
+      "Yan"
+    ]
+  },
+  "English (Ireland)": {
+    "ShortName": [
+      "en-IE-ConnorNeural",
+      "en-IE-EmilyNeural"
+    ],
+    "LocalName": [
+      "Connor",
+      "Emily"
+    ]
+  },
+  "English (India)": {
+    "ShortName": [
+      "en-IN-NeerjaNeural",
+      "en-IN-PrabhatNeural"
+    ],
+    "LocalName": [
+      "Neerja",
+      "Prabhat"
+    ]
+  },
+  "English (Kenya)": {
+    "ShortName": [
+      "en-KE-AsiliaNeural",
+      "en-KE-ChilembaNeural"
+    ],
+    "LocalName": [
+      "Asilia",
+      "Chilemba"
+    ]
+  },
+  "English (Nigeria)": {
+    "ShortName": [
+      "en-NG-AbeoNeural",
+      "en-NG-EzinneNeural"
+    ],
+    "LocalName": [
+      "Abeo",
+      "Ezinne"
+    ]
+  },
+  "English (New Zealand)": {
+    "ShortName": [
+      "en-NZ-MitchellNeural",
+      "en-NZ-MollyNeural"
+    ],
+    "LocalName": [
+      "Mitchell",
+      "Molly"
+    ]
+  },
+  "English (Philippines)": {
+    "ShortName": [
+      "en-PH-JamesNeural",
+      "en-PH-RosaNeural"
+    ],
+    "LocalName": [
+      "James",
+      "Rosa"
+    ]
+  },
+  "English (Singapore)": {
+    "ShortName": [
+      "en-SG-LunaNeural",
+      "en-SG-WayneNeural"
+    ],
+    "LocalName": [
+      "Luna",
+      "Wayne"
+    ]
+  },
+  "English (Tanzania)": {
+    "ShortName": [
+      "en-TZ-ElimuNeural",
+      "en-TZ-ImaniNeural"
+    ],
+    "LocalName": [
+      "Elimu",
+      "Imani"
+    ]
+  },
+  "English (United States)": {
+    "ShortName": [
+      "en-US-JennyNeural",
+      "en-US-JennyMultilingualNeural",
+      "en-US-GuyNeural",
+      "en-US-AmberNeural",
+      "en-US-AnaNeural",
+      "en-US-AriaNeural",
+      "en-US-AshleyNeural",
+      "en-US-BrandonNeural",
+      "en-US-ChristopherNeural",
+      "en-US-CoraNeural",
+      "en-US-DavisNeural",
+      "en-US-ElizabethNeural",
+      "en-US-EricNeural",
+      "en-US-JacobNeural",
+      "en-US-JaneNeural",
+      "en-US-JasonNeural",
+      "en-US-MichelleNeural",
+      "en-US-MonicaNeural",
+      "en-US-NancyNeural",
+      "en-US-SaraNeural",
+      "en-US-TonyNeural",
+      "en-US-AIGenerate1Neural",
+      "en-US-AIGenerate2Neural",
+      "en-US-RogerNeural",
+      "en-US-SteffanNeural"
+    ],
+    "LocalName": [
+      "Jenny",
+      "Jenny Multilingual",
+      "Guy",
+      "Amber",
+      "Ana",
+      "Aria",
+      "Ashley",
+      "Brandon",
+      "Christopher",
+      "Cora",
+      "Davis",
+      "Elizabeth",
+      "Eric",
+      "Jacob",
+      "Jane",
+      "Jason",
+      "Michelle",
+      "Monica",
+      "Nancy",
+      "Sara",
+      "Tony",
+      "AIGenerate1",
+      "AIGenerate2",
+      "Roger",
+      "Steffan"
+    ]
+  },
+  "English (South Africa)": {
+    "ShortName": [
+      "en-ZA-LeahNeural",
+      "en-ZA-LukeNeural"
+    ],
+    "LocalName": [
+      "Leah",
+      "Luke"
+    ]
+  },
+  "Afrikaans (South Africa)": {
+    "ShortName": [
+      "af-ZA-AdriNeural",
+      "af-ZA-WillemNeural"
+    ],
+    "LocalName": [
+      "Adri",
+      "Willem"
+    ]
+  },
+  "Amharic (Ethiopia)": {
+    "ShortName": [
+      "am-ET-AmehaNeural",
+      "am-ET-MekdesNeural"
+    ],
+    "LocalName": [
+      "አምሀ",
+      "መቅደስ"
+    ]
+  },
+  "Arabic (United Arab Emirates)": {
+    "ShortName": [
+      "ar-AE-FatimaNeural",
+      "ar-AE-HamdanNeural"
+    ],
+    "LocalName": [
+      "فاطمة",
+      "حمدان"
+    ]
+  },
+  "Arabic (Bahrain)": {
+    "ShortName": [
+      "ar-BH-AliNeural",
+      "ar-BH-LailaNeural"
+    ],
+    "LocalName": [
+      "علي",
+      "ليلى"
+    ]
+  },
+  "Arabic (Algeria)": {
+    "ShortName": [
+      "ar-DZ-AminaNeural",
+      "ar-DZ-IsmaelNeural"
+    ],
+    "LocalName": [
+      "أمينة",
+      "إسماعيل"
+    ]
+  },
+  "Arabic (Egypt)": {
+    "ShortName": [
+      "ar-EG-SalmaNeural",
+      "ar-EG-ShakirNeural"
+    ],
+    "LocalName": [
+      "سلمى",
+      "شاكر"
+    ]
+  },
+  "Arabic (Iraq)": {
+    "ShortName": [
+      "ar-IQ-BasselNeural",
+      "ar-IQ-RanaNeural"
+    ],
+    "LocalName": [
+      "باسل",
+      "رنا"
+    ]
+  },
+  "Arabic (Jordan)": {
+    "ShortName": [
+      "ar-JO-SanaNeural",
+      "ar-JO-TaimNeural"
+    ],
+    "LocalName": [
+      "سناء",
+      "تيم"
+    ]
+  },
+  "Arabic (Kuwait)": {
+    "ShortName": [
+      "ar-KW-FahedNeural",
+      "ar-KW-NouraNeural"
+    ],
+    "LocalName": [
+      "فهد",
+      "نورا"
+    ]
+  },
+  "Arabic (Lebanon)": {
+    "ShortName": [
+      "ar-LB-LaylaNeural",
+      "ar-LB-RamiNeural"
+    ],
+    "LocalName": [
+      "ليلى",
+      "رامي"
+    ]
+  },
+  "Arabic (Libya)": {
+    "ShortName": [
+      "ar-LY-ImanNeural",
+      "ar-LY-OmarNeural"
+    ],
+    "LocalName": [
+      "إيمان",
+      "أحمد"
+    ]
+  },
+  "Arabic (Morocco)": {
+    "ShortName": [
+      "ar-MA-JamalNeural",
+      "ar-MA-MounaNeural"
+    ],
+    "LocalName": [
+      "جمال",
+      "منى"
+    ]
+  },
+  "Arabic (Oman)": {
+    "ShortName": [
+      "ar-OM-AbdullahNeural",
+      "ar-OM-AyshaNeural"
+    ],
+    "LocalName": [
+      "عبدالله",
+      "عائشة"
+    ]
+  },
+  "Arabic (Qatar)": {
+    "ShortName": [
+      "ar-QA-AmalNeural",
+      "ar-QA-MoazNeural"
+    ],
+    "LocalName": [
+      "أمل",
+      "معاذ"
+    ]
+  },
+  "Arabic (Saudi Arabia)": {
+    "ShortName": [
+      "ar-SA-HamedNeural",
+      "ar-SA-ZariyahNeural"
+    ],
+    "LocalName": [
+      "حامد",
+      "زارية"
+    ]
+  },
+  "Arabic (Syria)": {
+    "ShortName": [
+      "ar-SY-AmanyNeural",
+      "ar-SY-LaithNeural"
+    ],
+    "LocalName": [
+      "أماني",
+      "ليث"
+    ]
+  },
+  "Arabic (Tunisia)": {
+    "ShortName": [
+      "ar-TN-HediNeural",
+      "ar-TN-ReemNeural"
+    ],
+    "LocalName": [
+      "هادي",
+      "ريم"
+    ]
+  },
+  "Arabic (Yemen)": {
+    "ShortName": [
+      "ar-YE-MaryamNeural",
+      "ar-YE-SalehNeural"
+    ],
+    "LocalName": [
+      "مريم",
+      "صالح"
+    ]
+  },
+  "Azerbaijani (Azerbaijan)": {
+    "ShortName": [
+      "az-AZ-BabekNeural",
+      "az-AZ-BanuNeural"
+    ],
+    "LocalName": [
+      "Babək",
+      "Banu"
+    ]
+  },
+  "Bulgarian (Bulgaria)": {
+    "ShortName": [
+      "bg-BG-BorislavNeural",
+      "bg-BG-KalinaNeural"
+    ],
+    "LocalName": [
+      "Борислав",
+      "Калина"
+    ]
+  },
+  "Bangla (Bangladesh)": {
+    "ShortName": [
+      "bn-BD-NabanitaNeural",
+      "bn-BD-PradeepNeural"
+    ],
+    "LocalName": [
+      "নবনীতা",
+      "প্রদ্বীপ"
+    ]
+  },
+  "Bengali (India)": {
+    "ShortName": [
+      "bn-IN-BashkarNeural",
+      "bn-IN-TanishaaNeural"
+    ],
+    "LocalName": [
+      "ভাস্কর",
+      "তানিশা"
+    ]
+  },
+  "Bosnian (Bosnia)": {
+    "ShortName": [
+      "bs-BA-GoranNeural",
+      "bs-BA-VesnaNeural"
+    ],
+    "LocalName": [
+      "Goran",
+      "Vesna"
+    ]
+  },
+  "Catalan (Spain)": {
+    "ShortName": [
+      "ca-ES-JoanaNeural",
+      "ca-ES-AlbaNeural",
+      "ca-ES-EnricNeural"
+    ],
+    "LocalName": [
+      "Joana",
+      "Alba",
+      "Enric"
+    ]
+  },
+  "Czech (Czech)": {
+    "ShortName": [
+      "cs-CZ-AntoninNeural",
+      "cs-CZ-VlastaNeural"
+    ],
+    "LocalName": [
+      "Antonín",
+      "Vlasta"
+    ]
+  },
+  "Welsh (United Kingdom)": {
+    "ShortName": [
+      "cy-GB-AledNeural",
+      "cy-GB-NiaNeural"
+    ],
+    "LocalName": [
+      "Aled",
+      "Nia"
+    ]
+  },
+  "Danish (Denmark)": {
+    "ShortName": [
+      "da-DK-ChristelNeural",
+      "da-DK-JeppeNeural"
+    ],
+    "LocalName": [
+      "Christel",
+      "Jeppe"
+    ]
+  },
+  "German (Austria)": {
+    "ShortName": [
+      "de-AT-IngridNeural",
+      "de-AT-JonasNeural"
+    ],
+    "LocalName": [
+      "Ingrid",
+      "Jonas"
+    ]
+  },
+  "German (Switzerland)": {
+    "ShortName": [
+      "de-CH-JanNeural",
+      "de-CH-LeniNeural"
+    ],
+    "LocalName": [
+      "Jan",
+      "Leni"
+    ]
+  },
+  "German (Germany)": {
+    "ShortName": [
+      "de-DE-KatjaNeural",
+      "de-DE-AmalaNeural",
+      "de-DE-BerndNeural",
+      "de-DE-ChristophNeural",
+      "de-DE-ConradNeural",
+      "de-DE-ElkeNeural",
+      "de-DE-GiselaNeural",
+      "de-DE-KasperNeural",
+      "de-DE-KillianNeural",
+      "de-DE-KlarissaNeural",
+      "de-DE-KlausNeural",
+      "de-DE-LouisaNeural",
+      "de-DE-MajaNeural",
+      "de-DE-RalfNeural",
+      "de-DE-TanjaNeural"
+    ],
+    "LocalName": [
+      "Katja",
+      "Amala",
+      "Bernd",
+      "Christoph",
+      "Conrad",
+      "Elke",
+      "Gisela",
+      "Kasper",
+      "Killian",
+      "Klarissa",
+      "Klaus",
+      "Louisa",
+      "Maja",
+      "Ralf",
+      "Tanja"
+    ]
+  },
+  "Greek (Greece)": {
+    "ShortName": [
+      "el-GR-AthinaNeural",
+      "el-GR-NestorasNeural"
+    ],
+    "LocalName": [
+      "Αθηνά",
+      "Νέστορας"
+    ]
+  },
+  "Spanish (Argentina)": {
+    "ShortName": [
+      "es-AR-ElenaNeural",
+      "es-AR-TomasNeural"
+    ],
+    "LocalName": [
+      "Elena",
+      "Tomas"
+    ]
+  },
+  "Spanish (Bolivia)": {
+    "ShortName": [
+      "es-BO-MarceloNeural",
+      "es-BO-SofiaNeural"
+    ],
+    "LocalName": [
+      "Marcelo",
+      "Sofia"
+    ]
+  },
+  "Spanish (Chile)": {
+    "ShortName": [
+      "es-CL-CatalinaNeural",
+      "es-CL-LorenzoNeural"
+    ],
+    "LocalName": [
+      "Catalina",
+      "Lorenzo"
+    ]
+  },
+  "Spanish (Colombia)": {
+    "ShortName": [
+      "es-CO-GonzaloNeural",
+      "es-CO-SalomeNeural"
+    ],
+    "LocalName": [
+      "Gonzalo",
+      "Salome"
+    ]
+  },
+  "Spanish (Costa Rica)": {
+    "ShortName": [
+      "es-CR-JuanNeural",
+      "es-CR-MariaNeural"
+    ],
+    "LocalName": [
+      "Juan",
+      "María"
+    ]
+  },
+  "Spanish (Cuba)": {
+    "ShortName": [
+      "es-CU-BelkysNeural",
+      "es-CU-ManuelNeural"
+    ],
+    "LocalName": [
+      "Belkys",
+      "Manuel"
+    ]
+  },
+  "Spanish (Dominican Republic)": {
+    "ShortName": [
+      "es-DO-EmilioNeural",
+      "es-DO-RamonaNeural"
+    ],
+    "LocalName": [
+      "Emilio",
+      "Ramona"
+    ]
+  },
+  "Spanish (Ecuador)": {
+    "ShortName": [
+      "es-EC-AndreaNeural",
+      "es-EC-LuisNeural"
+    ],
+    "LocalName": [
+      "Andrea",
+      "Luis"
+    ]
+  },
+  "Spanish (Spain)": {
+    "ShortName": [
+      "es-ES-ElviraNeural",
+      "es-ES-AbrilNeural",
+      "es-ES-AlvaroNeural",
+      "es-ES-ArnauNeural",
+      "es-ES-DarioNeural",
+      "es-ES-EliasNeural",
+      "es-ES-EstrellaNeural",
+      "es-ES-IreneNeural",
+      "es-ES-LaiaNeural",
+      "es-ES-LiaNeural",
+      "es-ES-NilNeural",
+      "es-ES-SaulNeural",
+      "es-ES-TeoNeural",
+      "es-ES-TrianaNeural",
+      "es-ES-VeraNeural"
+    ],
+    "LocalName": [
+      "Elvira",
+      "Abril",
+      "Álvaro",
+      "Arnau",
+      "Dario",
+      "Elias",
+      "Estrella",
+      "Irene",
+      "Laia",
+      "Lia",
+      "Nil",
+      "Saul",
+      "Teo",
+      "Triana",
+      "Vera"
+    ]
+  },
+  "Spanish (Equatorial Guinea)": {
+    "ShortName": [
+      "es-GQ-JavierNeural",
+      "es-GQ-TeresaNeural"
+    ],
+    "LocalName": [
+      "Javier",
+      "Teresa"
+    ]
+  },
+  "Spanish (Guatemala)": {
+    "ShortName": [
+      "es-GT-AndresNeural",
+      "es-GT-MartaNeural"
+    ],
+    "LocalName": [
+      "Andrés",
+      "Marta"
+    ]
+  },
+  "Spanish (Honduras)": {
+    "ShortName": [
+      "es-HN-CarlosNeural",
+      "es-HN-KarlaNeural"
+    ],
+    "LocalName": [
+      "Carlos",
+      "Karla"
+    ]
+  },
+  "Spanish (Mexico)": {
+    "ShortName": [
+      "es-MX-DaliaNeural",
+      "es-MX-BeatrizNeural",
+      "es-MX-CandelaNeural",
+      "es-MX-CarlotaNeural",
+      "es-MX-CecilioNeural",
+      "es-MX-GerardoNeural",
+      "es-MX-JorgeNeural",
+      "es-MX-LarissaNeural",
+      "es-MX-LibertoNeural",
+      "es-MX-LucianoNeural",
+      "es-MX-MarinaNeural",
+      "es-MX-NuriaNeural",
+      "es-MX-PelayoNeural",
+      "es-MX-RenataNeural",
+      "es-MX-YagoNeural"
+    ],
+    "LocalName": [
+      "Dalia",
+      "Beatriz",
+      "Candela",
+      "Carlota",
+      "Cecilio",
+      "Gerardo",
+      "Jorge",
+      "Larissa",
+      "Liberto",
+      "Luciano",
+      "Marina",
+      "Nuria",
+      "Pelayo",
+      "Renata",
+      "Yago"
+    ]
+  },
+  "Spanish (Nicaragua)": {
+    "ShortName": [
+      "es-NI-FedericoNeural",
+      "es-NI-YolandaNeural"
+    ],
+    "LocalName": [
+      "Federico",
+      "Yolanda"
+    ]
+  },
+  "Spanish (Panama)": {
+    "ShortName": [
+      "es-PA-MargaritaNeural",
+      "es-PA-RobertoNeural"
+    ],
+    "LocalName": [
+      "Margarita",
+      "Roberto"
+    ]
+  },
+  "Spanish (Peru)": {
+    "ShortName": [
+      "es-PE-AlexNeural",
+      "es-PE-CamilaNeural"
+    ],
+    "LocalName": [
+      "Alex",
+      "Camila"
+    ]
+  },
+  "Spanish (Puerto Rico)": {
+    "ShortName": [
+      "es-PR-KarinaNeural",
+      "es-PR-VictorNeural"
+    ],
+    "LocalName": [
+      "Karina",
+      "Víctor"
+    ]
+  },
+  "Spanish (Paraguay)": {
+    "ShortName": [
+      "es-PY-MarioNeural",
+      "es-PY-TaniaNeural"
+    ],
+    "LocalName": [
+      "Mario",
+      "Tania"
+    ]
+  },
+  "Spanish (El Salvador)": {
+    "ShortName": [
+      "es-SV-LorenaNeural",
+      "es-SV-RodrigoNeural"
+    ],
+    "LocalName": [
+      "Lorena",
+      "Rodrigo"
+    ]
+  },
+  "Spanish (United States)": {
+    "ShortName": [
+      "es-US-AlonsoNeural",
+      "es-US-PalomaNeural"
+    ],
+    "LocalName": [
+      "Alonso",
+      "Paloma"
+    ]
+  },
+  "Spanish (Uruguay)": {
+    "ShortName": [
+      "es-UY-MateoNeural",
+      "es-UY-ValentinaNeural"
+    ],
+    "LocalName": [
+      "Mateo",
+      "Valentina"
+    ]
+  },
+  "Spanish (Venezuela)": {
+    "ShortName": [
+      "es-VE-PaolaNeural",
+      "es-VE-SebastianNeural"
+    ],
+    "LocalName": [
+      "Paola",
+      "Sebastián"
+    ]
+  },
+  "Estonian (Estonia)": {
+    "ShortName": [
+      "et-EE-AnuNeural",
+      "et-EE-KertNeural"
+    ],
+    "LocalName": [
+      "Anu",
+      "Kert"
+    ]
+  },
+  "Basque": {
+    "ShortName": [
+      "eu-ES-AinhoaNeural",
+      "eu-ES-AnderNeural"
+    ],
+    "LocalName": [
+      "Ainhoa",
+      "Ander"
+    ]
+  },
+  "Persian (Iran)": {
+    "ShortName": [
+      "fa-IR-DilaraNeural",
+      "fa-IR-FaridNeural"
+    ],
+    "LocalName": [
+      "دلارا",
+      "فرید"
+    ]
+  },
+  "Finnish (Finland)": {
+    "ShortName": [
+      "fi-FI-SelmaNeural",
+      "fi-FI-HarriNeural",
+      "fi-FI-NooraNeural"
+    ],
+    "LocalName": [
+      "Selma",
+      "Harri",
+      "Noora"
+    ]
+  },
+  "Filipino (Philippines)": {
+    "ShortName": [
+      "fil-PH-AngeloNeural",
+      "fil-PH-BlessicaNeural"
+    ],
+    "LocalName": [
+      "Angelo",
+      "Blessica"
+    ]
+  },
+  "French (Belgium)": {
+    "ShortName": [
+      "fr-BE-CharlineNeural",
+      "fr-BE-GerardNeural"
+    ],
+    "LocalName": [
+      "Charline",
+      "Gerard"
+    ]
+  },
+  "French (Canada)": {
+    "ShortName": [
+      "fr-CA-SylvieNeural",
+      "fr-CA-AntoineNeural",
+      "fr-CA-JeanNeural"
+    ],
+    "LocalName": [
+      "Sylvie",
+      "Antoine",
+      "Jean"
+    ]
+  },
+  "French (Switzerland)": {
+    "ShortName": [
+      "fr-CH-ArianeNeural",
+      "fr-CH-FabriceNeural"
+    ],
+    "LocalName": [
+      "Ariane",
+      "Fabrice"
+    ]
+  },
+  "French (France)": {
+    "ShortName": [
+      "fr-FR-AlainNeural",
+      "fr-FR-BrigitteNeural",
+      "fr-FR-CelesteNeural",
+      "fr-FR-ClaudeNeural",
+      "fr-FR-CoralieNeural",
+      "fr-FR-EloiseNeural",
+      "fr-FR-JacquelineNeural",
+      "fr-FR-JeromeNeural",
+      "fr-FR-JosephineNeural",
+      "fr-FR-MauriceNeural",
+      "fr-FR-YvesNeural",
+      "fr-FR-YvetteNeural",
+      "fr-FR-DeniseNeural",
+      "fr-FR-HenriNeural"
+    ],
+    "LocalName": [
+      "Alain",
+      "Brigitte",
+      "Celeste",
+      "Claude",
+      "Coralie",
+      "Eloise",
+      "Jacqueline",
+      "Jerome",
+      "Josephine",
+      "Maurice",
+      "Yves",
+      "Yvette",
+      "Denise",
+      "Henri"
+    ]
+  },
+  "Irish (Ireland)": {
+    "ShortName": [
+      "ga-IE-ColmNeural",
+      "ga-IE-OrlaNeural"
+    ],
+    "LocalName": [
+      "Colm",
+      "Orla"
+    ]
+  },
+  "Galicia": {
+    "ShortName": [
+      "gl-ES-RoiNeural",
+      "gl-ES-SabelaNeural"
+    ],
+    "LocalName": [
+      "Roi",
+      "Sabela"
+    ]
+  },
+  "Gujarati (India)": {
+    "ShortName": [
+      "gu-IN-DhwaniNeural",
+      "gu-IN-NiranjanNeural"
+    ],
+    "LocalName": [
+      "ધ્વની",
+      "નિરંજન"
+    ]
+  },
+  "Hebrew (Israel)": {
+    "ShortName": [
+      "he-IL-AvriNeural",
+      "he-IL-HilaNeural"
+    ],
+    "LocalName": [
+      "אברי",
+      "הילה"
+    ]
+  },
+  "Hindi (India)": {
+    "ShortName": [
+      "hi-IN-MadhurNeural",
+      "hi-IN-SwaraNeural"
+    ],
+    "LocalName": [
+      "मधुर",
+      "स्वरा"
+    ]
+  },
+  "Croatian (Croatia)": {
+    "ShortName": [
+      "hr-HR-GabrijelaNeural",
+      "hr-HR-SreckoNeural"
+    ],
+    "LocalName": [
+      "Gabrijela",
+      "Srećko"
+    ]
+  },
+  "Hungarian (Hungary)": {
+    "ShortName": [
+      "hu-HU-NoemiNeural",
+      "hu-HU-TamasNeural"
+    ],
+    "LocalName": [
+      "Noémi",
+      "Tamás"
+    ]
+  },
+  "Armenian (Armenia)": {
+    "ShortName": [
+      "hy-AM-AnahitNeural",
+      "hy-AM-HaykNeural"
+    ],
+    "LocalName": [
+      "Անահիտ",
+      "Հայկ"
+    ]
+  },
+  "Indonesian (Indonesia)": {
+    "ShortName": [
+      "id-ID-ArdiNeural",
+      "id-ID-GadisNeural"
+    ],
+    "LocalName": [
+      "Ardi",
+      "Gadis"
+    ]
+  },
+  "Icelandic (Iceland)": {
+    "ShortName": [
+      "is-IS-GudrunNeural",
+      "is-IS-GunnarNeural"
+    ],
+    "LocalName": [
+      "Guðrún",
+      "Gunnar"
+    ]
+  },
+  "Italian (Italy)": {
+    "ShortName": [
+      "it-IT-IsabellaNeural",
+      "it-IT-ElsaNeural",
+      "it-IT-BenignoNeural",
+      "it-IT-CalimeroNeural",
+      "it-IT-CataldoNeural",
+      "it-IT-DiegoNeural",
+      "it-IT-FabiolaNeural",
+      "it-IT-FiammaNeural",
+      "it-IT-GianniNeural",
+      "it-IT-ImeldaNeural",
+      "it-IT-IrmaNeural",
+      "it-IT-LisandroNeural",
+      "it-IT-PalmiraNeural",
+      "it-IT-PierinaNeural",
+      "it-IT-RinaldoNeural"
+    ],
+    "LocalName": [
+      "Isabella",
+      "Elsa",
+      "Benigno",
+      "Calimero",
+      "Cataldo",
+      "Diego",
+      "Fabiola",
+      "Fiamma",
+      "Gianni",
+      "Imelda",
+      "Irma",
+      "Lisandro",
+      "Palmira",
+      "Pierina",
+      "Rinaldo"
+    ]
+  },
+  "Japanese (Japan)": {
+    "ShortName": [
+      "ja-JP-NanamiNeural",
+      "ja-JP-KeitaNeural",
+      "ja-JP-AoiNeural",
+      "ja-JP-DaichiNeural",
+      "ja-JP-MayuNeural",
+      "ja-JP-NaokiNeural",
+      "ja-JP-ShioriNeural"
+    ],
+    "LocalName": [
+      "七海",
+      "圭太",
+      "碧衣",
+      "大智",
+      "真夕",
+      "直紀",
+      "志織"
+    ]
+  },
+  "Javanese (Indonesia)": {
+    "ShortName": [
+      "jv-ID-DimasNeural",
+      "jv-ID-SitiNeural"
+    ],
+    "LocalName": [
+      "Dimas",
+      "Siti"
+    ]
+  },
+  "Georgian (Georgia)": {
+    "ShortName": [
+      "ka-GE-EkaNeural",
+      "ka-GE-GiorgiNeural"
+    ],
+    "LocalName": [
+      "ეკა",
+      "გიორგი"
+    ]
+  },
+  "Kazakh (Kazakhstan)": {
+    "ShortName": [
+      "kk-KZ-AigulNeural",
+      "kk-KZ-DauletNeural"
+    ],
+    "LocalName": [
+      "Айгүл",
+      "Дәулет"
+    ]
+  },
+  "Khmer (Cambodia)": {
+    "ShortName": [
+      "km-KH-PisethNeural",
+      "km-KH-SreymomNeural"
+    ],
+    "LocalName": [
+      "ពិសិដ្ឋ",
+      "ស្រីមុំ"
+    ]
+  },
+  "Kannada (India)": {
+    "ShortName": [
+      "kn-IN-GaganNeural",
+      "kn-IN-SapnaNeural"
+    ],
+    "LocalName": [
+      "ಗಗನ್",
+      "ಸಪ್ನಾ"
+    ]
+  },
+  "Korean (Korea)": {
+    "ShortName": [
+      "ko-KR-SunHiNeural",
+      "ko-KR-InJoonNeural",
+      "ko-KR-BongJinNeural",
+      "ko-KR-GookMinNeural",
+      "ko-KR-JiMinNeural",
+      "ko-KR-SeoHyeonNeural",
+      "ko-KR-SoonBokNeural",
+      "ko-KR-YuJinNeural"
+    ],
+    "LocalName": [
+      "선히",
+      "인준",
+      "봉진",
+      "국민",
+      "지민",
+      "서현",
+      "순복",
+      "유진"
+    ]
+  },
+  "Lao (Laos)": {
+    "ShortName": [
+      "lo-LA-ChanthavongNeural",
+      "lo-LA-KeomanyNeural"
+    ],
+    "LocalName": [
+      "ຈັນທະວົງ",
+      "ແກ້ວມະນີ"
+    ]
+  },
+  "Lithuanian (Lithuania)": {
+    "ShortName": [
+      "lt-LT-LeonasNeural",
+      "lt-LT-OnaNeural"
+    ],
+    "LocalName": [
+      "Leonas",
+      "Ona"
+    ]
+  },
+  "Latvian (Latvia)": {
+    "ShortName": [
+      "lv-LV-EveritaNeural",
+      "lv-LV-NilsNeural"
+    ],
+    "LocalName": [
+      "Everita",
+      "Nils"
+    ]
+  },
+  "Macedonian (Republic of North Macedonia)": {
+    "ShortName": [
+      "mk-MK-AleksandarNeural",
+      "mk-MK-MarijaNeural"
+    ],
+    "LocalName": [
+      "Александар",
+      "Марија"
+    ]
+  },
+  "Malayalam (India)": {
+    "ShortName": [
+      "ml-IN-MidhunNeural",
+      "ml-IN-SobhanaNeural"
+    ],
+    "LocalName": [
+      "മിഥുൻ",
+      "ശോഭന"
+    ]
+  },
+  "Mongolian (Mongolia)": {
+    "ShortName": [
+      "mn-MN-BataaNeural",
+      "mn-MN-YesuiNeural"
+    ],
+    "LocalName": [
+      "Батаа",
+      "Есүй"
+    ]
+  },
+  "Marathi (India)": {
+    "ShortName": [
+      "mr-IN-AarohiNeural",
+      "mr-IN-ManoharNeural"
+    ],
+    "LocalName": [
+      "आरोही",
+      "मनोहर"
+    ]
+  },
+  "Malay (Malaysia)": {
+    "ShortName": [
+      "ms-MY-OsmanNeural",
+      "ms-MY-YasminNeural"
+    ],
+    "LocalName": [
+      "Osman",
+      "Yasmin"
+    ]
+  },
+  "Maltese (Malta)": {
+    "ShortName": [
+      "mt-MT-GraceNeural",
+      "mt-MT-JosephNeural"
+    ],
+    "LocalName": [
+      "Grace",
+      "Joseph"
+    ]
+  },
+  "Burmese (Myanmar)": {
+    "ShortName": [
+      "my-MM-NilarNeural",
+      "my-MM-ThihaNeural"
+    ],
+    "LocalName": [
+      "နီလာ",
+      "သီဟ"
+    ]
+  },
+  "Norwegian (Bokmål, Norway)": {
+    "ShortName": [
+      "nb-NO-PernilleNeural",
+      "nb-NO-FinnNeural",
+      "nb-NO-IselinNeural"
+    ],
+    "LocalName": [
+      "Pernille",
+      "Finn",
+      "Iselin"
+    ]
+  },
+  "Nepali (Nepal)": {
+    "ShortName": [
+      "ne-NP-HemkalaNeural",
+      "ne-NP-SagarNeural"
+    ],
+    "LocalName": [
+      "हेमकला",
+      "सागर"
+    ]
+  },
+  "Dutch (Belgium)": {
+    "ShortName": [
+      "nl-BE-ArnaudNeural",
+      "nl-BE-DenaNeural"
+    ],
+    "LocalName": [
+      "Arnaud",
+      "Dena"
+    ]
+  },
+  "Dutch (Netherlands)": {
+    "ShortName": [
+      "nl-NL-ColetteNeural",
+      "nl-NL-FennaNeural",
+      "nl-NL-MaartenNeural"
+    ],
+    "LocalName": [
+      "Colette",
+      "Fenna",
+      "Maarten"
+    ]
+  },
+  "Polish (Poland)": {
+    "ShortName": [
+      "pl-PL-AgnieszkaNeural",
+      "pl-PL-MarekNeural",
+      "pl-PL-ZofiaNeural"
+    ],
+    "LocalName": [
+      "Agnieszka",
+      "Marek",
+      "Zofia"
+    ]
+  },
+  "Pashto (Afghanistan)": {
+    "ShortName": [
+      "ps-AF-GulNawazNeural",
+      "ps-AF-LatifaNeural"
+    ],
+    "LocalName": [
+      " ګل نواز",
+      "لطيفه"
+    ]
+  },
+  "Portuguese (Brazil)": {
+    "ShortName": [
+      "pt-BR-FranciscaNeural",
+      "pt-BR-AntonioNeural",
+      "pt-BR-BrendaNeural",
+      "pt-BR-DonatoNeural",
+      "pt-BR-ElzaNeural",
+      "pt-BR-FabioNeural",
+      "pt-BR-GiovannaNeural",
+      "pt-BR-HumbertoNeural",
+      "pt-BR-JulioNeural",
+      "pt-BR-LeilaNeural",
+      "pt-BR-LeticiaNeural",
+      "pt-BR-ManuelaNeural",
+      "pt-BR-NicolauNeural",
+      "pt-BR-ValerioNeural",
+      "pt-BR-YaraNeural"
+    ],
+    "LocalName": [
+      "Francisca",
+      "Antônio",
+      "Brenda",
+      "Donato",
+      "Elza",
+      "Fabio",
+      "Giovanna",
+      "Humberto",
+      "Julio",
+      "Leila",
+      "Leticia",
+      "Manuela",
+      "Nicolau",
+      "Valerio",
+      "Yara"
+    ]
+  },
+  "Portuguese (Portugal)": {
+    "ShortName": [
+      "pt-PT-DuarteNeural",
+      "pt-PT-FernandaNeural",
+      "pt-PT-RaquelNeural"
+    ],
+    "LocalName": [
+      "Duarte",
+      "Fernanda",
+      "Raquel"
+    ]
+  },
+  "Romanian (Romania)": {
+    "ShortName": [
+      "ro-RO-AlinaNeural",
+      "ro-RO-EmilNeural"
+    ],
+    "LocalName": [
+      "Alina",
+      "Emil"
+    ]
+  },
+  "Russian (Russia)": {
+    "ShortName": [
+      "ru-RU-SvetlanaNeural",
+      "ru-RU-DariyaNeural",
+      "ru-RU-DmitryNeural"
+    ],
+    "LocalName": [
+      "Светлана",
+      "Дария",
+      "Дмитрий"
+    ]
+  },
+  "Sinhala (Sri Lanka)": {
+    "ShortName": [
+      "si-LK-SameeraNeural",
+      "si-LK-ThiliniNeural"
+    ],
+    "LocalName": [
+      "සමීර",
+      "තිළිණි"
+    ]
+  },
+  "Slovak (Slovakia)": {
+    "ShortName": [
+      "sk-SK-LukasNeural",
+      "sk-SK-ViktoriaNeural"
+    ],
+    "LocalName": [
+      "Lukáš",
+      "Viktória"
+    ]
+  },
+  "Slovenian (Slovenia)": {
+    "ShortName": [
+      "sl-SI-PetraNeural",
+      "sl-SI-RokNeural"
+    ],
+    "LocalName": [
+      "Petra",
+      "Rok"
+    ]
+  },
+  "Somali (Somalia)": {
+    "ShortName": [
+      "so-SO-MuuseNeural",
+      "so-SO-UbaxNeural"
+    ],
+    "LocalName": [
+      "Muuse",
+      "Ubax"
+    ]
+  },
+  "Albanian (Albania)": {
+    "ShortName": [
+      "sq-AL-AnilaNeural",
+      "sq-AL-IlirNeural"
+    ],
+    "LocalName": [
+      "Anila",
+      "Ilir"
+    ]
+  },
+  "Serbian (Serbia)": {
+    "ShortName": [
+      "sr-RS-NicholasNeural",
+      "sr-RS-SophieNeural"
+    ],
+    "LocalName": [
+      "Никола",
+      "Софија"
+    ]
+  },
+  "Sundanese (Indonesia)": {
+    "ShortName": [
+      "su-ID-JajangNeural",
+      "su-ID-TutiNeural"
+    ],
+    "LocalName": [
+      "Jajang",
+      "Tuti"
+    ]
+  },
+  "Swedish (Sweden)": {
+    "ShortName": [
+      "sv-SE-SofieNeural",
+      "sv-SE-HilleviNeural",
+      "sv-SE-MattiasNeural"
+    ],
+    "LocalName": [
+      "Sofie",
+      "Hillevi",
+      "Mattias"
+    ]
+  },
+  "Swahili (Kenya)": {
+    "ShortName": [
+      "sw-KE-RafikiNeural",
+      "sw-KE-ZuriNeural"
+    ],
+    "LocalName": [
+      "Rafiki",
+      "Zuri"
+    ]
+  },
+  "Swahili (Tanzania)": {
+    "ShortName": [
+      "sw-TZ-DaudiNeural",
+      "sw-TZ-RehemaNeural"
+    ],
+    "LocalName": [
+      "Daudi",
+      "Rehema"
+    ]
+  },
+  "Tamil (India)": {
+    "ShortName": [
+      "ta-IN-PallaviNeural",
+      "ta-IN-ValluvarNeural"
+    ],
+    "LocalName": [
+      "பல்லவி",
+      "வள்ளுவர்"
+    ]
+  },
+  "Tamil (Sri Lanka)": {
+    "ShortName": [
+      "ta-LK-KumarNeural",
+      "ta-LK-SaranyaNeural"
+    ],
+    "LocalName": [
+      "குமார்",
+      "சரண்யா"
+    ]
+  },
+  "Tamil (Malaysia)": {
+    "ShortName": [
+      "ta-MY-KaniNeural",
+      "ta-MY-SuryaNeural"
+    ],
+    "LocalName": [
+      "கனி",
+      "சூர்யா"
+    ]
+  },
+  "Tamil (Singapore)": {
+    "ShortName": [
+      "ta-SG-AnbuNeural",
+      "ta-SG-VenbaNeural"
+    ],
+    "LocalName": [
+      "அன்பு",
+      "வெண்பா"
+    ]
+  },
+  "Telugu (India)": {
+    "ShortName": [
+      "te-IN-MohanNeural",
+      "te-IN-ShrutiNeural"
+    ],
+    "LocalName": [
+      "మోహన్",
+      "శ్రుతి"
+    ]
+  },
+  "Thai (Thailand)": {
+    "ShortName": [
+      "th-TH-PremwadeeNeural",
+      "th-TH-AcharaNeural",
+      "th-TH-NiwatNeural"
+    ],
+    "LocalName": [
+      "เปรมวดี",
+      "อัจฉรา",
+      "นิวัฒน์"
+    ]
+  },
+  "Turkish (Turkey)": {
+    "ShortName": [
+      "tr-TR-AhmetNeural",
+      "tr-TR-EmelNeural"
+    ],
+    "LocalName": [
+      "Ahmet",
+      "Emel"
+    ]
+  },
+  "Ukrainian (Ukraine)": {
+    "ShortName": [
+      "uk-UA-OstapNeural",
+      "uk-UA-PolinaNeural"
+    ],
+    "LocalName": [
+      "Остап",
+      "Поліна"
+    ]
+  },
+  "Urdu (India)": {
+    "ShortName": [
+      "ur-IN-GulNeural",
+      "ur-IN-SalmanNeural"
+    ],
+    "LocalName": [
+      "گل",
+      "سلمان"
+    ]
+  },
+  "Urdu (Pakistan)": {
+    "ShortName": [
+      "ur-PK-AsadNeural",
+      "ur-PK-UzmaNeural"
+    ],
+    "LocalName": [
+      "اسد",
+      "عظمیٰ"
+    ]
+  },
+  "Uzbek (Uzbekistan)": {
+    "ShortName": [
+      "uz-UZ-MadinaNeural",
+      "uz-UZ-SardorNeural"
+    ],
+    "LocalName": [
+      "Madina",
+      "Sardor"
+    ]
+  },
+  "Vietnamese (Vietnam)": {
+    "ShortName": [
+      "vi-VN-HoaiMyNeural",
+      "vi-VN-NamMinhNeural"
+    ],
+    "LocalName": [
+      "Hoài My",
+      "Nam Minh"
+    ]
+  },
+  "Zulu (South Africa)": {
+    "ShortName": [
+      "zu-ZA-ThandoNeural",
+      "zu-ZA-ThandoNeural"
+    ],
+    "LocalName": [
+      "Thando",
+      "Thando"
+    ]
+  }
+};
+export const ttsVoiceList = [{"name":"wuu-CN-XiaotongNeural","LocalName":"晓彤","dialect":"中文（上海话，简体）"},{"name":"wuu-CN-YunzheNeural","LocalName":"云哲","dialect":"中文（上海话，简体）"},{"name":"yue-CN-XiaoMinNeural","LocalName":"晓敏","dialect":"中文（广东话，简体）"},{"name":"yue-CN-YunSongNeural","LocalName":"云松","dialect":"中文（广东话，简体）"},{"name":"zh-CN-XiaoxiaoNeural","LocalName":"晓晓（女 - 年轻人）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-YunyangNeural","LocalName":"云扬（男 - 年轻人）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-YunxiNeural","LocalName":"云希（男 - 年轻人 - 抖音热门）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-XiaoyiNeural","LocalName":"晓伊（女 - 儿童）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-YunjianNeural","LocalName":"云健（男 - 中年人）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-YunxiaNeural","LocalName":"云夏（男 - 儿童）","dialect":"中文（普通话，简体）"},{"name":"zh-CN-henan-YundengNeural","LocalName":"云登","dialect":"中文（河南话，简体）"},{"name":"zh-CN-liaoning-XiaobeiNeural","LocalName":"晓北","dialect":"中文（东北话，简体）"},{"name":"zh-CN-shaanxi-XiaoniNeural","LocalName":"晓妮","dialect":"中文（陕西话，简体）"},{"name":"zh-CN-shandong-YunxiangNeural","LocalName":"云翔","dialect":"中文（山东话，简体）"},{"name":"zh-CN-sichuan-YunxiNeural","LocalName":"云希","dialect":"中文（四川话，简体）"},{"name":"zh-HK-HiuMaanNeural","LocalName":"曉曼","dialect":"中文（香港话，繁体）"},{"name":"zh-HK-HiuGaaiNeural","LocalName":"曉佳","dialect":"中文（香港话，繁体）"},{"name":"zh-HK-WanLungNeural","LocalName":"雲龍","dialect":"中文（香港话，繁体）"},{"name":"zh-TW-HsiaoChenNeural","LocalName":"曉臻","dialect":"中文（台湾话，繁体）"},{"name":"zh-TW-HsiaoYuNeural","LocalName":"曉雨","dialect":"中文（台湾话，繁体）"},{"name":"zh-TW-YunJheNeural","LocalName":"雲哲","dialect":"中文（台湾话，繁体）"},{"name":"en-AU-NatashaNeural","LocalName":"Natasha","dialect":"English (Australia)"},{"name":"en-AU-WilliamNeural","LocalName":"William","dialect":"English (Australia)"},{"name":"en-AU-AnnetteNeural","LocalName":"Annette","dialect":"English (Australia)"},{"name":"en-AU-CarlyNeural","LocalName":"Carly","dialect":"English (Australia)"},{"name":"en-AU-DarrenNeural","LocalName":"Darren","dialect":"English (Australia)"},{"name":"en-AU-DuncanNeural","LocalName":"Duncan","dialect":"English (Australia)"},{"name":"en-AU-ElsieNeural","LocalName":"Elsie","dialect":"English (Australia)"},{"name":"en-AU-FreyaNeural","LocalName":"Freya","dialect":"English (Australia)"},{"name":"en-AU-JoanneNeural","LocalName":"Joanne","dialect":"English (Australia)"},{"name":"en-AU-KenNeural","LocalName":"Ken","dialect":"English (Australia)"},{"name":"en-AU-KimNeural","LocalName":"Kim","dialect":"English (Australia)"},{"name":"en-AU-NeilNeural","LocalName":"Neil","dialect":"English (Australia)"},{"name":"en-AU-TimNeural","LocalName":"Tim","dialect":"English (Australia)"},{"name":"en-AU-TinaNeural","LocalName":"Tina","dialect":"English (Australia)"},{"name":"en-CA-ClaraNeural","LocalName":"Clara","dialect":"English (Canada)"},{"name":"en-CA-LiamNeural","LocalName":"Liam","dialect":"English (Canada)"},{"name":"en-GB-LibbyNeural","LocalName":"Libby","dialect":"English (United Kingdom)"},{"name":"en-GB-AbbiNeural","LocalName":"Abbi","dialect":"English (United Kingdom)"},{"name":"en-GB-AlfieNeural","LocalName":"Alfie","dialect":"English (United Kingdom)"},{"name":"en-GB-BellaNeural","LocalName":"Bella","dialect":"English (United Kingdom)"},{"name":"en-GB-ElliotNeural","LocalName":"Elliot","dialect":"English (United Kingdom)"},{"name":"en-GB-EthanNeural","LocalName":"Ethan","dialect":"English (United Kingdom)"},{"name":"en-GB-HollieNeural","LocalName":"Hollie","dialect":"English (United Kingdom)"},{"name":"en-GB-MaisieNeural","LocalName":"Maisie","dialect":"English (United Kingdom)"},{"name":"en-GB-NoahNeural","LocalName":"Noah","dialect":"English (United Kingdom)"},{"name":"en-GB-OliverNeural","LocalName":"Oliver","dialect":"English (United Kingdom)"},{"name":"en-GB-OliviaNeural","LocalName":"Olivia","dialect":"English (United Kingdom)"},{"name":"en-GB-ThomasNeural","LocalName":"Thomas","dialect":"English (United Kingdom)"},{"name":"en-GB-RyanNeural","LocalName":"Ryan","dialect":"English (United Kingdom)"},{"name":"en-GB-SoniaNeural","LocalName":"Sonia","dialect":"English (United Kingdom)"},{"name":"en-GB-MiaNeural","LocalName":"Mia","dialect":"English (United Kingdom)"},{"name":"en-HK-SamNeural","LocalName":"Sam","dialect":"English (Hongkong)"},{"name":"en-HK-YanNeural","LocalName":"Yan","dialect":"English (Hongkong)"},{"name":"en-IE-ConnorNeural","LocalName":"Connor","dialect":"English (Ireland)"},{"name":"en-IE-EmilyNeural","LocalName":"Emily","dialect":"English (Ireland)"},{"name":"en-IN-NeerjaNeural","LocalName":"Neerja","dialect":"English (India)"},{"name":"en-IN-PrabhatNeural","LocalName":"Prabhat","dialect":"English (India)"},{"name":"en-KE-AsiliaNeural","LocalName":"Asilia","dialect":"English (Kenya)"},{"name":"en-KE-ChilembaNeural","LocalName":"Chilemba","dialect":"English (Kenya)"},{"name":"en-NG-AbeoNeural","LocalName":"Abeo","dialect":"English (Nigeria)"},{"name":"en-NG-EzinneNeural","LocalName":"Ezinne","dialect":"English (Nigeria)"},{"name":"en-NZ-MitchellNeural","LocalName":"Mitchell","dialect":"English (New Zealand)"},{"name":"en-NZ-MollyNeural","LocalName":"Molly","dialect":"English (New Zealand)"},{"name":"en-PH-JamesNeural","LocalName":"James","dialect":"English (Philippines)"},{"name":"en-PH-RosaNeural","LocalName":"Rosa","dialect":"English (Philippines)"},{"name":"en-SG-LunaNeural","LocalName":"Luna","dialect":"English (Singapore)"},{"name":"en-SG-WayneNeural","LocalName":"Wayne","dialect":"English (Singapore)"},{"name":"en-TZ-ElimuNeural","LocalName":"Elimu","dialect":"English (Tanzania)"},{"name":"en-TZ-ImaniNeural","LocalName":"Imani","dialect":"English (Tanzania)"},{"name":"en-US-JennyNeural","LocalName":"Jenny","dialect":"English (United States)"},{"name":"en-US-JennyMultilingualNeural","LocalName":"Jenny Multilingual","dialect":"English (United States)"},{"name":"en-US-GuyNeural","LocalName":"Guy","dialect":"English (United States)"},{"name":"en-US-AmberNeural","LocalName":"Amber","dialect":"English (United States)"},{"name":"en-US-AnaNeural","LocalName":"Ana","dialect":"English (United States)"},{"name":"en-US-AriaNeural","LocalName":"Aria","dialect":"English (United States)"},{"name":"en-US-AshleyNeural","LocalName":"Ashley","dialect":"English (United States)"},{"name":"en-US-BrandonNeural","LocalName":"Brandon","dialect":"English (United States)"},{"name":"en-US-ChristopherNeural","LocalName":"Christopher","dialect":"English (United States)"},{"name":"en-US-CoraNeural","LocalName":"Cora","dialect":"English (United States)"},{"name":"en-US-DavisNeural","LocalName":"Davis","dialect":"English (United States)"},{"name":"en-US-ElizabethNeural","LocalName":"Elizabeth","dialect":"English (United States)"},{"name":"en-US-EricNeural","LocalName":"Eric","dialect":"English (United States)"},{"name":"en-US-JacobNeural","LocalName":"Jacob","dialect":"English (United States)"},{"name":"en-US-JaneNeural","LocalName":"Jane","dialect":"English (United States)"},{"name":"en-US-JasonNeural","LocalName":"Jason","dialect":"English (United States)"},{"name":"en-US-MichelleNeural","LocalName":"Michelle","dialect":"English (United States)"},{"name":"en-US-MonicaNeural","LocalName":"Monica","dialect":"English (United States)"},{"name":"en-US-NancyNeural","LocalName":"Nancy","dialect":"English (United States)"},{"name":"en-US-SaraNeural","LocalName":"Sara","dialect":"English (United States)"},{"name":"en-US-TonyNeural","LocalName":"Tony","dialect":"English (United States)"},{"name":"en-US-AIGenerate1Neural","LocalName":"AIGenerate1","dialect":"English (United States)"},{"name":"en-US-AIGenerate2Neural","LocalName":"AIGenerate2","dialect":"English (United States)"},{"name":"en-US-RogerNeural","LocalName":"Roger","dialect":"English (United States)"},{"name":"en-US-SteffanNeural","LocalName":"Steffan","dialect":"English (United States)"},{"name":"en-ZA-LeahNeural","LocalName":"Leah","dialect":"English (South Africa)"},{"name":"en-ZA-LukeNeural","LocalName":"Luke","dialect":"English (South Africa)"},{"name":"af-ZA-AdriNeural","LocalName":"Adri","dialect":"Afrikaans (South Africa)"},{"name":"af-ZA-WillemNeural","LocalName":"Willem","dialect":"Afrikaans (South Africa)"},{"name":"am-ET-AmehaNeural","LocalName":"አምሀ","dialect":"Amharic (Ethiopia)"},{"name":"am-ET-MekdesNeural","LocalName":"መቅደስ","dialect":"Amharic (Ethiopia)"},{"name":"ar-AE-FatimaNeural","LocalName":"فاطمة","dialect":"Arabic (United Arab Emirates)"},{"name":"ar-AE-HamdanNeural","LocalName":"حمدان","dialect":"Arabic (United Arab Emirates)"},{"name":"ar-BH-AliNeural","LocalName":"علي","dialect":"Arabic (Bahrain)"},{"name":"ar-BH-LailaNeural","LocalName":"ليلى","dialect":"Arabic (Bahrain)"},{"name":"ar-DZ-AminaNeural","LocalName":"أمينة","dialect":"Arabic (Algeria)"},{"name":"ar-DZ-IsmaelNeural","LocalName":"إسماعيل","dialect":"Arabic (Algeria)"},{"name":"ar-EG-SalmaNeural","LocalName":"سلمى","dialect":"Arabic (Egypt)"},{"name":"ar-EG-ShakirNeural","LocalName":"شاكر","dialect":"Arabic (Egypt)"},{"name":"ar-IQ-BasselNeural","LocalName":"باسل","dialect":"Arabic (Iraq)"},{"name":"ar-IQ-RanaNeural","LocalName":"رنا","dialect":"Arabic (Iraq)"},{"name":"ar-JO-SanaNeural","LocalName":"سناء","dialect":"Arabic (Jordan)"},{"name":"ar-JO-TaimNeural","LocalName":"تيم","dialect":"Arabic (Jordan)"},{"name":"ar-KW-FahedNeural","LocalName":"فهد","dialect":"Arabic (Kuwait)"},{"name":"ar-KW-NouraNeural","LocalName":"نورا","dialect":"Arabic (Kuwait)"},{"name":"ar-LB-LaylaNeural","LocalName":"ليلى","dialect":"Arabic (Lebanon)"},{"name":"ar-LB-RamiNeural","LocalName":"رامي","dialect":"Arabic (Lebanon)"},{"name":"ar-LY-ImanNeural","LocalName":"إيمان","dialect":"Arabic (Libya)"},{"name":"ar-LY-OmarNeural","LocalName":"أحمد","dialect":"Arabic (Libya)"},{"name":"ar-MA-JamalNeural","LocalName":"جمال","dialect":"Arabic (Morocco)"},{"name":"ar-MA-MounaNeural","LocalName":"منى","dialect":"Arabic (Morocco)"},{"name":"ar-OM-AbdullahNeural","LocalName":"عبدالله","dialect":"Arabic (Oman)"},{"name":"ar-OM-AyshaNeural","LocalName":"عائشة","dialect":"Arabic (Oman)"},{"name":"ar-QA-AmalNeural","LocalName":"أمل","dialect":"Arabic (Qatar)"},{"name":"ar-QA-MoazNeural","LocalName":"معاذ","dialect":"Arabic (Qatar)"},{"name":"ar-SA-HamedNeural","LocalName":"حامد","dialect":"Arabic (Saudi Arabia)"},{"name":"ar-SA-ZariyahNeural","LocalName":"زارية","dialect":"Arabic (Saudi Arabia)"},{"name":"ar-SY-AmanyNeural","LocalName":"أماني","dialect":"Arabic (Syria)"},{"name":"ar-SY-LaithNeural","LocalName":"ليث","dialect":"Arabic (Syria)"},{"name":"ar-TN-HediNeural","LocalName":"هادي","dialect":"Arabic (Tunisia)"},{"name":"ar-TN-ReemNeural","LocalName":"ريم","dialect":"Arabic (Tunisia)"},{"name":"ar-YE-MaryamNeural","LocalName":"مريم","dialect":"Arabic (Yemen)"},{"name":"ar-YE-SalehNeural","LocalName":"صالح","dialect":"Arabic (Yemen)"},{"name":"az-AZ-BabekNeural","LocalName":"Babək","dialect":"Azerbaijani (Azerbaijan)"},{"name":"az-AZ-BanuNeural","LocalName":"Banu","dialect":"Azerbaijani (Azerbaijan)"},{"name":"bg-BG-BorislavNeural","LocalName":"Борислав","dialect":"Bulgarian (Bulgaria)"},{"name":"bg-BG-KalinaNeural","LocalName":"Калина","dialect":"Bulgarian (Bulgaria)"},{"name":"bn-BD-NabanitaNeural","LocalName":"নবনীতা","dialect":"Bangla (Bangladesh)"},{"name":"bn-BD-PradeepNeural","LocalName":"প্রদ্বীপ","dialect":"Bangla (Bangladesh)"},{"name":"bn-IN-BashkarNeural","LocalName":"ভাস্কর","dialect":"Bengali (India)"},{"name":"bn-IN-TanishaaNeural","LocalName":"তানিশা","dialect":"Bengali (India)"},{"name":"bs-BA-GoranNeural","LocalName":"Goran","dialect":"Bosnian (Bosnia)"},{"name":"bs-BA-VesnaNeural","LocalName":"Vesna","dialect":"Bosnian (Bosnia)"},{"name":"ca-ES-JoanaNeural","LocalName":"Joana","dialect":"Catalan (Spain)"},{"name":"ca-ES-AlbaNeural","LocalName":"Alba","dialect":"Catalan (Spain)"},{"name":"ca-ES-EnricNeural","LocalName":"Enric","dialect":"Catalan (Spain)"},{"name":"cs-CZ-AntoninNeural","LocalName":"Antonín","dialect":"Czech (Czech)"},{"name":"cs-CZ-VlastaNeural","LocalName":"Vlasta","dialect":"Czech (Czech)"},{"name":"cy-GB-AledNeural","LocalName":"Aled","dialect":"Welsh (United Kingdom)"},{"name":"cy-GB-NiaNeural","LocalName":"Nia","dialect":"Welsh (United Kingdom)"},{"name":"da-DK-ChristelNeural","LocalName":"Christel","dialect":"Danish (Denmark)"},{"name":"da-DK-JeppeNeural","LocalName":"Jeppe","dialect":"Danish (Denmark)"},{"name":"de-AT-IngridNeural","LocalName":"Ingrid","dialect":"German (Austria)"},{"name":"de-AT-JonasNeural","LocalName":"Jonas","dialect":"German (Austria)"},{"name":"de-CH-JanNeural","LocalName":"Jan","dialect":"German (Switzerland)"},{"name":"de-CH-LeniNeural","LocalName":"Leni","dialect":"German (Switzerland)"},{"name":"de-DE-KatjaNeural","LocalName":"Katja","dialect":"German (Germany)"},{"name":"de-DE-AmalaNeural","LocalName":"Amala","dialect":"German (Germany)"},{"name":"de-DE-BerndNeural","LocalName":"Bernd","dialect":"German (Germany)"},{"name":"de-DE-ChristophNeural","LocalName":"Christoph","dialect":"German (Germany)"},{"name":"de-DE-ConradNeural","LocalName":"Conrad","dialect":"German (Germany)"},{"name":"de-DE-ElkeNeural","LocalName":"Elke","dialect":"German (Germany)"},{"name":"de-DE-GiselaNeural","LocalName":"Gisela","dialect":"German (Germany)"},{"name":"de-DE-KasperNeural","LocalName":"Kasper","dialect":"German (Germany)"},{"name":"de-DE-KillianNeural","LocalName":"Killian","dialect":"German (Germany)"},{"name":"de-DE-KlarissaNeural","LocalName":"Klarissa","dialect":"German (Germany)"},{"name":"de-DE-KlausNeural","LocalName":"Klaus","dialect":"German (Germany)"},{"name":"de-DE-LouisaNeural","LocalName":"Louisa","dialect":"German (Germany)"},{"name":"de-DE-MajaNeural","LocalName":"Maja","dialect":"German (Germany)"},{"name":"de-DE-RalfNeural","LocalName":"Ralf","dialect":"German (Germany)"},{"name":"de-DE-TanjaNeural","LocalName":"Tanja","dialect":"German (Germany)"},{"name":"el-GR-AthinaNeural","LocalName":"Αθηνά","dialect":"Greek (Greece)"},{"name":"el-GR-NestorasNeural","LocalName":"Νέστορας","dialect":"Greek (Greece)"},{"name":"es-AR-ElenaNeural","LocalName":"Elena","dialect":"Spanish (Argentina)"},{"name":"es-AR-TomasNeural","LocalName":"Tomas","dialect":"Spanish (Argentina)"},{"name":"es-BO-MarceloNeural","LocalName":"Marcelo","dialect":"Spanish (Bolivia)"},{"name":"es-BO-SofiaNeural","LocalName":"Sofia","dialect":"Spanish (Bolivia)"},{"name":"es-CL-CatalinaNeural","LocalName":"Catalina","dialect":"Spanish (Chile)"},{"name":"es-CL-LorenzoNeural","LocalName":"Lorenzo","dialect":"Spanish (Chile)"},{"name":"es-CO-GonzaloNeural","LocalName":"Gonzalo","dialect":"Spanish (Colombia)"},{"name":"es-CO-SalomeNeural","LocalName":"Salome","dialect":"Spanish (Colombia)"},{"name":"es-CR-JuanNeural","LocalName":"Juan","dialect":"Spanish (Costa Rica)"},{"name":"es-CR-MariaNeural","LocalName":"María","dialect":"Spanish (Costa Rica)"},{"name":"es-CU-BelkysNeural","LocalName":"Belkys","dialect":"Spanish (Cuba)"},{"name":"es-CU-ManuelNeural","LocalName":"Manuel","dialect":"Spanish (Cuba)"},{"name":"es-DO-EmilioNeural","LocalName":"Emilio","dialect":"Spanish (Dominican Republic)"},{"name":"es-DO-RamonaNeural","LocalName":"Ramona","dialect":"Spanish (Dominican Republic)"},{"name":"es-EC-AndreaNeural","LocalName":"Andrea","dialect":"Spanish (Ecuador)"},{"name":"es-EC-LuisNeural","LocalName":"Luis","dialect":"Spanish (Ecuador)"},{"name":"es-ES-ElviraNeural","LocalName":"Elvira","dialect":"Spanish (Spain)"},{"name":"es-ES-AbrilNeural","LocalName":"Abril","dialect":"Spanish (Spain)"},{"name":"es-ES-AlvaroNeural","LocalName":"Álvaro","dialect":"Spanish (Spain)"},{"name":"es-ES-ArnauNeural","LocalName":"Arnau","dialect":"Spanish (Spain)"},{"name":"es-ES-DarioNeural","LocalName":"Dario","dialect":"Spanish (Spain)"},{"name":"es-ES-EliasNeural","LocalName":"Elias","dialect":"Spanish (Spain)"},{"name":"es-ES-EstrellaNeural","LocalName":"Estrella","dialect":"Spanish (Spain)"},{"name":"es-ES-IreneNeural","LocalName":"Irene","dialect":"Spanish (Spain)"},{"name":"es-ES-LaiaNeural","LocalName":"Laia","dialect":"Spanish (Spain)"},{"name":"es-ES-LiaNeural","LocalName":"Lia","dialect":"Spanish (Spain)"},{"name":"es-ES-NilNeural","LocalName":"Nil","dialect":"Spanish (Spain)"},{"name":"es-ES-SaulNeural","LocalName":"Saul","dialect":"Spanish (Spain)"},{"name":"es-ES-TeoNeural","LocalName":"Teo","dialect":"Spanish (Spain)"},{"name":"es-ES-TrianaNeural","LocalName":"Triana","dialect":"Spanish (Spain)"},{"name":"es-ES-VeraNeural","LocalName":"Vera","dialect":"Spanish (Spain)"},{"name":"es-GQ-JavierNeural","LocalName":"Javier","dialect":"Spanish (Equatorial Guinea)"},{"name":"es-GQ-TeresaNeural","LocalName":"Teresa","dialect":"Spanish (Equatorial Guinea)"},{"name":"es-GT-AndresNeural","LocalName":"Andrés","dialect":"Spanish (Guatemala)"},{"name":"es-GT-MartaNeural","LocalName":"Marta","dialect":"Spanish (Guatemala)"},{"name":"es-HN-CarlosNeural","LocalName":"Carlos","dialect":"Spanish (Honduras)"},{"name":"es-HN-KarlaNeural","LocalName":"Karla","dialect":"Spanish (Honduras)"},{"name":"es-MX-DaliaNeural","LocalName":"Dalia","dialect":"Spanish (Mexico)"},{"name":"es-MX-BeatrizNeural","LocalName":"Beatriz","dialect":"Spanish (Mexico)"},{"name":"es-MX-CandelaNeural","LocalName":"Candela","dialect":"Spanish (Mexico)"},{"name":"es-MX-CarlotaNeural","LocalName":"Carlota","dialect":"Spanish (Mexico)"},{"name":"es-MX-CecilioNeural","LocalName":"Cecilio","dialect":"Spanish (Mexico)"},{"name":"es-MX-GerardoNeural","LocalName":"Gerardo","dialect":"Spanish (Mexico)"},{"name":"es-MX-JorgeNeural","LocalName":"Jorge","dialect":"Spanish (Mexico)"},{"name":"es-MX-LarissaNeural","LocalName":"Larissa","dialect":"Spanish (Mexico)"},{"name":"es-MX-LibertoNeural","LocalName":"Liberto","dialect":"Spanish (Mexico)"},{"name":"es-MX-LucianoNeural","LocalName":"Luciano","dialect":"Spanish (Mexico)"},{"name":"es-MX-MarinaNeural","LocalName":"Marina","dialect":"Spanish (Mexico)"},{"name":"es-MX-NuriaNeural","LocalName":"Nuria","dialect":"Spanish (Mexico)"},{"name":"es-MX-PelayoNeural","LocalName":"Pelayo","dialect":"Spanish (Mexico)"},{"name":"es-MX-RenataNeural","LocalName":"Renata","dialect":"Spanish (Mexico)"},{"name":"es-MX-YagoNeural","LocalName":"Yago","dialect":"Spanish (Mexico)"},{"name":"es-NI-FedericoNeural","LocalName":"Federico","dialect":"Spanish (Nicaragua)"},{"name":"es-NI-YolandaNeural","LocalName":"Yolanda","dialect":"Spanish (Nicaragua)"},{"name":"es-PA-MargaritaNeural","LocalName":"Margarita","dialect":"Spanish (Panama)"},{"name":"es-PA-RobertoNeural","LocalName":"Roberto","dialect":"Spanish (Panama)"},{"name":"es-PE-AlexNeural","LocalName":"Alex","dialect":"Spanish (Peru)"},{"name":"es-PE-CamilaNeural","LocalName":"Camila","dialect":"Spanish (Peru)"},{"name":"es-PR-KarinaNeural","LocalName":"Karina","dialect":"Spanish (Puerto Rico)"},{"name":"es-PR-VictorNeural","LocalName":"Víctor","dialect":"Spanish (Puerto Rico)"},{"name":"es-PY-MarioNeural","LocalName":"Mario","dialect":"Spanish (Paraguay)"},{"name":"es-PY-TaniaNeural","LocalName":"Tania","dialect":"Spanish (Paraguay)"},{"name":"es-SV-LorenaNeural","LocalName":"Lorena","dialect":"Spanish (El Salvador)"},{"name":"es-SV-RodrigoNeural","LocalName":"Rodrigo","dialect":"Spanish (El Salvador)"},{"name":"es-US-AlonsoNeural","LocalName":"Alonso","dialect":"Spanish (United States)"},{"name":"es-US-PalomaNeural","LocalName":"Paloma","dialect":"Spanish (United States)"},{"name":"es-UY-MateoNeural","LocalName":"Mateo","dialect":"Spanish (Uruguay)"},{"name":"es-UY-ValentinaNeural","LocalName":"Valentina","dialect":"Spanish (Uruguay)"},{"name":"es-VE-PaolaNeural","LocalName":"Paola","dialect":"Spanish (Venezuela)"},{"name":"es-VE-SebastianNeural","LocalName":"Sebastián","dialect":"Spanish (Venezuela)"},{"name":"et-EE-AnuNeural","LocalName":"Anu","dialect":"Estonian (Estonia)"},{"name":"et-EE-KertNeural","LocalName":"Kert","dialect":"Estonian (Estonia)"},{"name":"eu-ES-AinhoaNeural","LocalName":"Ainhoa","dialect":"Basque"},{"name":"eu-ES-AnderNeural","LocalName":"Ander","dialect":"Basque"},{"name":"fa-IR-DilaraNeural","LocalName":"دلارا","dialect":"Persian (Iran)"},{"name":"fa-IR-FaridNeural","LocalName":"فرید","dialect":"Persian (Iran)"},{"name":"fi-FI-SelmaNeural","LocalName":"Selma","dialect":"Finnish (Finland)"},{"name":"fi-FI-HarriNeural","LocalName":"Harri","dialect":"Finnish (Finland)"},{"name":"fi-FI-NooraNeural","LocalName":"Noora","dialect":"Finnish (Finland)"},{"name":"fil-PH-AngeloNeural","LocalName":"Angelo","dialect":"Filipino (Philippines)"},{"name":"fil-PH-BlessicaNeural","LocalName":"Blessica","dialect":"Filipino (Philippines)"},{"name":"fr-BE-CharlineNeural","LocalName":"Charline","dialect":"French (Belgium)"},{"name":"fr-BE-GerardNeural","LocalName":"Gerard","dialect":"French (Belgium)"},{"name":"fr-CA-SylvieNeural","LocalName":"Sylvie","dialect":"French (Canada)"},{"name":"fr-CA-AntoineNeural","LocalName":"Antoine","dialect":"French (Canada)"},{"name":"fr-CA-JeanNeural","LocalName":"Jean","dialect":"French (Canada)"},{"name":"fr-CH-ArianeNeural","LocalName":"Ariane","dialect":"French (Switzerland)"},{"name":"fr-CH-FabriceNeural","LocalName":"Fabrice","dialect":"French (Switzerland)"},{"name":"fr-FR-AlainNeural","LocalName":"Alain","dialect":"French (France)"},{"name":"fr-FR-BrigitteNeural","LocalName":"Brigitte","dialect":"French (France)"},{"name":"fr-FR-CelesteNeural","LocalName":"Celeste","dialect":"French (France)"},{"name":"fr-FR-ClaudeNeural","LocalName":"Claude","dialect":"French (France)"},{"name":"fr-FR-CoralieNeural","LocalName":"Coralie","dialect":"French (France)"},{"name":"fr-FR-EloiseNeural","LocalName":"Eloise","dialect":"French (France)"},{"name":"fr-FR-JacquelineNeural","LocalName":"Jacqueline","dialect":"French (France)"},{"name":"fr-FR-JeromeNeural","LocalName":"Jerome","dialect":"French (France)"},{"name":"fr-FR-JosephineNeural","LocalName":"Josephine","dialect":"French (France)"},{"name":"fr-FR-MauriceNeural","LocalName":"Maurice","dialect":"French (France)"},{"name":"fr-FR-YvesNeural","LocalName":"Yves","dialect":"French (France)"},{"name":"fr-FR-YvetteNeural","LocalName":"Yvette","dialect":"French (France)"},{"name":"fr-FR-DeniseNeural","LocalName":"Denise","dialect":"French (France)"},{"name":"fr-FR-HenriNeural","LocalName":"Henri","dialect":"French (France)"},{"name":"ga-IE-ColmNeural","LocalName":"Colm","dialect":"Irish (Ireland)"},{"name":"ga-IE-OrlaNeural","LocalName":"Orla","dialect":"Irish (Ireland)"},{"name":"gl-ES-RoiNeural","LocalName":"Roi","dialect":"Galicia"},{"name":"gl-ES-SabelaNeural","LocalName":"Sabela","dialect":"Galicia"},{"name":"gu-IN-DhwaniNeural","LocalName":"ધ્વની","dialect":"Gujarati (India)"},{"name":"gu-IN-NiranjanNeural","LocalName":"નિરંજન","dialect":"Gujarati (India)"},{"name":"he-IL-AvriNeural","LocalName":"אברי","dialect":"Hebrew (Israel)"},{"name":"he-IL-HilaNeural","LocalName":"הילה","dialect":"Hebrew (Israel)"},{"name":"hi-IN-MadhurNeural","LocalName":"मधुर","dialect":"Hindi (India)"},{"name":"hi-IN-SwaraNeural","LocalName":"स्वरा","dialect":"Hindi (India)"},{"name":"hr-HR-GabrijelaNeural","LocalName":"Gabrijela","dialect":"Croatian (Croatia)"},{"name":"hr-HR-SreckoNeural","LocalName":"Srećko","dialect":"Croatian (Croatia)"},{"name":"hu-HU-NoemiNeural","LocalName":"Noémi","dialect":"Hungarian (Hungary)"},{"name":"hu-HU-TamasNeural","LocalName":"Tamás","dialect":"Hungarian (Hungary)"},{"name":"hy-AM-AnahitNeural","LocalName":"Անահիտ","dialect":"Armenian (Armenia)"},{"name":"hy-AM-HaykNeural","LocalName":"Հայկ","dialect":"Armenian (Armenia)"},{"name":"id-ID-ArdiNeural","LocalName":"Ardi","dialect":"Indonesian (Indonesia)"},{"name":"id-ID-GadisNeural","LocalName":"Gadis","dialect":"Indonesian (Indonesia)"},{"name":"is-IS-GudrunNeural","LocalName":"Guðrún","dialect":"Icelandic (Iceland)"},{"name":"is-IS-GunnarNeural","LocalName":"Gunnar","dialect":"Icelandic (Iceland)"},{"name":"it-IT-IsabellaNeural","LocalName":"Isabella","dialect":"Italian (Italy)"},{"name":"it-IT-ElsaNeural","LocalName":"Elsa","dialect":"Italian (Italy)"},{"name":"it-IT-BenignoNeural","LocalName":"Benigno","dialect":"Italian (Italy)"},{"name":"it-IT-CalimeroNeural","LocalName":"Calimero","dialect":"Italian (Italy)"},{"name":"it-IT-CataldoNeural","LocalName":"Cataldo","dialect":"Italian (Italy)"},{"name":"it-IT-DiegoNeural","LocalName":"Diego","dialect":"Italian (Italy)"},{"name":"it-IT-FabiolaNeural","LocalName":"Fabiola","dialect":"Italian (Italy)"},{"name":"it-IT-FiammaNeural","LocalName":"Fiamma","dialect":"Italian (Italy)"},{"name":"it-IT-GianniNeural","LocalName":"Gianni","dialect":"Italian (Italy)"},{"name":"it-IT-ImeldaNeural","LocalName":"Imelda","dialect":"Italian (Italy)"},{"name":"it-IT-IrmaNeural","LocalName":"Irma","dialect":"Italian (Italy)"},{"name":"it-IT-LisandroNeural","LocalName":"Lisandro","dialect":"Italian (Italy)"},{"name":"it-IT-PalmiraNeural","LocalName":"Palmira","dialect":"Italian (Italy)"},{"name":"it-IT-PierinaNeural","LocalName":"Pierina","dialect":"Italian (Italy)"},{"name":"it-IT-RinaldoNeural","LocalName":"Rinaldo","dialect":"Italian (Italy)"},{"name":"ja-JP-NanamiNeural","LocalName":"七海","dialect":"Japanese (Japan)"},{"name":"ja-JP-KeitaNeural","LocalName":"圭太","dialect":"Japanese (Japan)"},{"name":"ja-JP-AoiNeural","LocalName":"碧衣","dialect":"Japanese (Japan)"},{"name":"ja-JP-DaichiNeural","LocalName":"大智","dialect":"Japanese (Japan)"},{"name":"ja-JP-MayuNeural","LocalName":"真夕","dialect":"Japanese (Japan)"},{"name":"ja-JP-NaokiNeural","LocalName":"直紀","dialect":"Japanese (Japan)"},{"name":"ja-JP-ShioriNeural","LocalName":"志織","dialect":"Japanese (Japan)"},{"name":"jv-ID-DimasNeural","LocalName":"Dimas","dialect":"Javanese (Indonesia)"},{"name":"jv-ID-SitiNeural","LocalName":"Siti","dialect":"Javanese (Indonesia)"},{"name":"ka-GE-EkaNeural","LocalName":"ეკა","dialect":"Georgian (Georgia)"},{"name":"ka-GE-GiorgiNeural","LocalName":"გიორგი","dialect":"Georgian (Georgia)"},{"name":"kk-KZ-AigulNeural","LocalName":"Айгүл","dialect":"Kazakh (Kazakhstan)"},{"name":"kk-KZ-DauletNeural","LocalName":"Дәулет","dialect":"Kazakh (Kazakhstan)"},{"name":"km-KH-PisethNeural","LocalName":"ពិសិដ្ឋ","dialect":"Khmer (Cambodia)"},{"name":"km-KH-SreymomNeural","LocalName":"ស្រីមុំ","dialect":"Khmer (Cambodia)"},{"name":"kn-IN-GaganNeural","LocalName":"ಗಗನ್","dialect":"Kannada (India)"},{"name":"kn-IN-SapnaNeural","LocalName":"ಸಪ್ನಾ","dialect":"Kannada (India)"},{"name":"ko-KR-SunHiNeural","LocalName":"선히","dialect":"Korean (Korea)"},{"name":"ko-KR-InJoonNeural","LocalName":"인준","dialect":"Korean (Korea)"},{"name":"ko-KR-BongJinNeural","LocalName":"봉진","dialect":"Korean (Korea)"},{"name":"ko-KR-GookMinNeural","LocalName":"국민","dialect":"Korean (Korea)"},{"name":"ko-KR-JiMinNeural","LocalName":"지민","dialect":"Korean (Korea)"},{"name":"ko-KR-SeoHyeonNeural","LocalName":"서현","dialect":"Korean (Korea)"},{"name":"ko-KR-SoonBokNeural","LocalName":"순복","dialect":"Korean (Korea)"},{"name":"ko-KR-YuJinNeural","LocalName":"유진","dialect":"Korean (Korea)"},{"name":"lo-LA-ChanthavongNeural","LocalName":"ຈັນທະວົງ","dialect":"Lao (Laos)"},{"name":"lo-LA-KeomanyNeural","LocalName":"ແກ້ວມະນີ","dialect":"Lao (Laos)"},{"name":"lt-LT-LeonasNeural","LocalName":"Leonas","dialect":"Lithuanian (Lithuania)"},{"name":"lt-LT-OnaNeural","LocalName":"Ona","dialect":"Lithuanian (Lithuania)"},{"name":"lv-LV-EveritaNeural","LocalName":"Everita","dialect":"Latvian (Latvia)"},{"name":"lv-LV-NilsNeural","LocalName":"Nils","dialect":"Latvian (Latvia)"},{"name":"mk-MK-AleksandarNeural","LocalName":"Александар","dialect":"Macedonian (Republic of North Macedonia)"},{"name":"mk-MK-MarijaNeural","LocalName":"Марија","dialect":"Macedonian (Republic of North Macedonia)"},{"name":"ml-IN-MidhunNeural","LocalName":"മിഥുൻ","dialect":"Malayalam (India)"},{"name":"ml-IN-SobhanaNeural","LocalName":"ശോഭന","dialect":"Malayalam (India)"},{"name":"mn-MN-BataaNeural","LocalName":"Батаа","dialect":"Mongolian (Mongolia)"},{"name":"mn-MN-YesuiNeural","LocalName":"Есүй","dialect":"Mongolian (Mongolia)"},{"name":"mr-IN-AarohiNeural","LocalName":"आरोही","dialect":"Marathi (India)"},{"name":"mr-IN-ManoharNeural","LocalName":"मनोहर","dialect":"Marathi (India)"},{"name":"ms-MY-OsmanNeural","LocalName":"Osman","dialect":"Malay (Malaysia)"},{"name":"ms-MY-YasminNeural","LocalName":"Yasmin","dialect":"Malay (Malaysia)"},{"name":"mt-MT-GraceNeural","LocalName":"Grace","dialect":"Maltese (Malta)"},{"name":"mt-MT-JosephNeural","LocalName":"Joseph","dialect":"Maltese (Malta)"},{"name":"my-MM-NilarNeural","LocalName":"နီလာ","dialect":"Burmese (Myanmar)"},{"name":"my-MM-ThihaNeural","LocalName":"သီဟ","dialect":"Burmese (Myanmar)"},{"name":"nb-NO-PernilleNeural","LocalName":"Pernille","dialect":"Norwegian (Bokmål, Norway)"},{"name":"nb-NO-FinnNeural","LocalName":"Finn","dialect":"Norwegian (Bokmål, Norway)"},{"name":"nb-NO-IselinNeural","LocalName":"Iselin","dialect":"Norwegian (Bokmål, Norway)"},{"name":"ne-NP-HemkalaNeural","LocalName":"हेमकला","dialect":"Nepali (Nepal)"},{"name":"ne-NP-SagarNeural","LocalName":"सागर","dialect":"Nepali (Nepal)"},{"name":"nl-BE-ArnaudNeural","LocalName":"Arnaud","dialect":"Dutch (Belgium)"},{"name":"nl-BE-DenaNeural","LocalName":"Dena","dialect":"Dutch (Belgium)"},{"name":"nl-NL-ColetteNeural","LocalName":"Colette","dialect":"Dutch (Netherlands)"},{"name":"nl-NL-FennaNeural","LocalName":"Fenna","dialect":"Dutch (Netherlands)"},{"name":"nl-NL-MaartenNeural","LocalName":"Maarten","dialect":"Dutch (Netherlands)"},{"name":"pl-PL-AgnieszkaNeural","LocalName":"Agnieszka","dialect":"Polish (Poland)"},{"name":"pl-PL-MarekNeural","LocalName":"Marek","dialect":"Polish (Poland)"},{"name":"pl-PL-ZofiaNeural","LocalName":"Zofia","dialect":"Polish (Poland)"},{"name":"ps-AF-GulNawazNeural","LocalName":" ګل نواز","dialect":"Pashto (Afghanistan)"},{"name":"ps-AF-LatifaNeural","LocalName":"لطيفه","dialect":"Pashto (Afghanistan)"},{"name":"pt-BR-FranciscaNeural","LocalName":"Francisca","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-AntonioNeural","LocalName":"Antônio","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-BrendaNeural","LocalName":"Brenda","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-DonatoNeural","LocalName":"Donato","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-ElzaNeural","LocalName":"Elza","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-FabioNeural","LocalName":"Fabio","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-GiovannaNeural","LocalName":"Giovanna","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-HumbertoNeural","LocalName":"Humberto","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-JulioNeural","LocalName":"Julio","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-LeilaNeural","LocalName":"Leila","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-LeticiaNeural","LocalName":"Leticia","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-ManuelaNeural","LocalName":"Manuela","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-NicolauNeural","LocalName":"Nicolau","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-ValerioNeural","LocalName":"Valerio","dialect":"Portuguese (Brazil)"},{"name":"pt-BR-YaraNeural","LocalName":"Yara","dialect":"Portuguese (Brazil)"},{"name":"pt-PT-DuarteNeural","LocalName":"Duarte","dialect":"Portuguese (Portugal)"},{"name":"pt-PT-FernandaNeural","LocalName":"Fernanda","dialect":"Portuguese (Portugal)"},{"name":"pt-PT-RaquelNeural","LocalName":"Raquel","dialect":"Portuguese (Portugal)"},{"name":"ro-RO-AlinaNeural","LocalName":"Alina","dialect":"Romanian (Romania)"},{"name":"ro-RO-EmilNeural","LocalName":"Emil","dialect":"Romanian (Romania)"},{"name":"ru-RU-SvetlanaNeural","LocalName":"Светлана","dialect":"Russian (Russia)"},{"name":"ru-RU-DariyaNeural","LocalName":"Дария","dialect":"Russian (Russia)"},{"name":"ru-RU-DmitryNeural","LocalName":"Дмитрий","dialect":"Russian (Russia)"},{"name":"si-LK-SameeraNeural","LocalName":"සමීර","dialect":"Sinhala (Sri Lanka)"},{"name":"si-LK-ThiliniNeural","LocalName":"තිළිණි","dialect":"Sinhala (Sri Lanka)"},{"name":"sk-SK-LukasNeural","LocalName":"Lukáš","dialect":"Slovak (Slovakia)"},{"name":"sk-SK-ViktoriaNeural","LocalName":"Viktória","dialect":"Slovak (Slovakia)"},{"name":"sl-SI-PetraNeural","LocalName":"Petra","dialect":"Slovenian (Slovenia)"},{"name":"sl-SI-RokNeural","LocalName":"Rok","dialect":"Slovenian (Slovenia)"},{"name":"so-SO-MuuseNeural","LocalName":"Muuse","dialect":"Somali (Somalia)"},{"name":"so-SO-UbaxNeural","LocalName":"Ubax","dialect":"Somali (Somalia)"},{"name":"sq-AL-AnilaNeural","LocalName":"Anila","dialect":"Albanian (Albania)"},{"name":"sq-AL-IlirNeural","LocalName":"Ilir","dialect":"Albanian (Albania)"},{"name":"sr-RS-NicholasNeural","LocalName":"Никола","dialect":"Serbian (Serbia)"},{"name":"sr-RS-SophieNeural","LocalName":"Софија","dialect":"Serbian (Serbia)"},{"name":"su-ID-JajangNeural","LocalName":"Jajang","dialect":"Sundanese (Indonesia)"},{"name":"su-ID-TutiNeural","LocalName":"Tuti","dialect":"Sundanese (Indonesia)"},{"name":"sv-SE-SofieNeural","LocalName":"Sofie","dialect":"Swedish (Sweden)"},{"name":"sv-SE-HilleviNeural","LocalName":"Hillevi","dialect":"Swedish (Sweden)"},{"name":"sv-SE-MattiasNeural","LocalName":"Mattias","dialect":"Swedish (Sweden)"},{"name":"sw-KE-RafikiNeural","LocalName":"Rafiki","dialect":"Swahili (Kenya)"},{"name":"sw-KE-ZuriNeural","LocalName":"Zuri","dialect":"Swahili (Kenya)"},{"name":"sw-TZ-DaudiNeural","LocalName":"Daudi","dialect":"Swahili (Tanzania)"},{"name":"sw-TZ-RehemaNeural","LocalName":"Rehema","dialect":"Swahili (Tanzania)"},{"name":"ta-IN-PallaviNeural","LocalName":"பல்லவி","dialect":"Tamil (India)"},{"name":"ta-IN-ValluvarNeural","LocalName":"வள்ளுவர்","dialect":"Tamil (India)"},{"name":"ta-LK-KumarNeural","LocalName":"குமார்","dialect":"Tamil (Sri Lanka)"},{"name":"ta-LK-SaranyaNeural","LocalName":"சரண்யா","dialect":"Tamil (Sri Lanka)"},{"name":"ta-MY-KaniNeural","LocalName":"கனி","dialect":"Tamil (Malaysia)"},{"name":"ta-MY-SuryaNeural","LocalName":"சூர்யா","dialect":"Tamil (Malaysia)"},{"name":"ta-SG-AnbuNeural","LocalName":"அன்பு","dialect":"Tamil (Singapore)"},{"name":"ta-SG-VenbaNeural","LocalName":"வெண்பா","dialect":"Tamil (Singapore)"},{"name":"te-IN-MohanNeural","LocalName":"మోహన్","dialect":"Telugu (India)"},{"name":"te-IN-ShrutiNeural","LocalName":"శ్రుతి","dialect":"Telugu (India)"},{"name":"th-TH-PremwadeeNeural","LocalName":"เปรมวดี","dialect":"Thai (Thailand)"},{"name":"th-TH-AcharaNeural","LocalName":"อัจฉรา","dialect":"Thai (Thailand)"},{"name":"th-TH-NiwatNeural","LocalName":"นิวัฒน์","dialect":"Thai (Thailand)"},{"name":"tr-TR-AhmetNeural","LocalName":"Ahmet","dialect":"Turkish (Turkey)"},{"name":"tr-TR-EmelNeural","LocalName":"Emel","dialect":"Turkish (Turkey)"},{"name":"uk-UA-OstapNeural","LocalName":"Остап","dialect":"Ukrainian (Ukraine)"},{"name":"uk-UA-PolinaNeural","LocalName":"Поліна","dialect":"Ukrainian (Ukraine)"},{"name":"ur-IN-GulNeural","LocalName":"گل","dialect":"Urdu (India)"},{"name":"ur-IN-SalmanNeural","LocalName":"سلمان","dialect":"Urdu (India)"},{"name":"ur-PK-AsadNeural","LocalName":"اسد","dialect":"Urdu (Pakistan)"},{"name":"ur-PK-UzmaNeural","LocalName":"عظمیٰ","dialect":"Urdu (Pakistan)"},{"name":"uz-UZ-MadinaNeural","LocalName":"Madina","dialect":"Uzbek (Uzbekistan)"},{"name":"uz-UZ-SardorNeural","LocalName":"Sardor","dialect":"Uzbek (Uzbekistan)"},{"name":"vi-VN-HoaiMyNeural","LocalName":"Hoài My","dialect":"Vietnamese (Vietnam)"},{"name":"vi-VN-NamMinhNeural","LocalName":"Nam Minh","dialect":"Vietnamese (Vietnam)"},{"name":"zu-ZA-ThandoNeural","LocalName":"Thando","dialect":"Zulu (South Africa)"},{"name":"zu-ZA-ThandoNeural","LocalName":"Thando","dialect":"Zulu (South Africa)"}];

--- a/web/src/views/Reader.vue
+++ b/web/src/views/Reader.vue
@@ -281,6 +281,7 @@ import jump from "../plugins/jump";
 import Animate from "../plugins/animate";
 import { setCache, getCache } from "../plugins/cache";
 import { simplized, traditionalized } from "../plugins/chinese";
+import { ttsVoiceList } from "../plugins/ttsVoices";
 import {
   cacheFirstRequest,
   LimitResquest,
@@ -893,24 +894,7 @@ export default {
         return this.localVoiceList;
       }
       if (this.ttsType === "edge") {
-        return [
-          "zh-CN-XiaoxiaoNeural",
-          "zh-CN-XiaoyiNeural",
-          "zh-CN-YunjianNeural",
-          "zh-CN-YunxiNeural",
-          "zh-CN-YunxiaNeural",
-          "zh-CN-YunyangNeural",
-          "zh-HK-HiuGaaiNeural",
-          "zh-HK-HiuMaanNeural",
-          "zh-HK-WanLungNeural",
-          "zh-TW-HsiaoChenNeural",
-          "zh-TW-YunJheNeural",
-          "zh-TW-HsiaoYuNeural",
-          "en-US-AriaNeural",
-          "en-US-ChristopherNeural",
-          "en-US-JennyNeural",
-          "en-US-GuyNeural"
-        ].map(name => ({ name, LocalName: name }));
+        return ttsVoiceList;
       }
       return this.$store.state.httpTTS || [];
     },


### PR DESCRIPTION
## 变更

从 reader-pro 3.2.14 JAR（reader bundle）逆向提取完整 Edge TTS 语音库：
- 147 种方言/语言（中文 10 种 + 英文 14 + 全球 123 种），共 441 个语音
- 每个语音含 ShortName/LocalName（与 JAR 语音选择 UI 一致）
- Reader.vue 的 edge 语音列表从硬编码 16 个 → 完整 ttsVoiceList（plugins/ttsVoices.js）

## 验证

构建通过；reader bundle 中文差异 80 → 40（剩余主要为 DPlayer 弹幕播放器，单独 PR）