### PR TITLE
fix: web/simple-web 对齐 JAR 资源与源码修复，发布 v4.0.4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,7 +70,16 @@ jobs:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: web-node-modules
+        with:
+          path: web/node_modules
+          key: ${{ runner.os }}-web-node-modules-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-web-node-modules-
       - name: Install dependencies
+        if: steps.web-node-modules.outputs.cache-hit != 'true'
         run: cd web && npm ci
       - name: Build web
         run: cd web && npm run build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,33 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/main/**'
+              - 'src/test/**'
+              - '*.gradle'
+              - '*.gradle.kts'
+              - 'gradle/**'
+              - 'settings.gradle'
+              - 'cli.gradle'
+              - 'build.gradle.kts'
+            web:
+              - 'web/**'
+              - 'simple-web-src/**'
+
+  build-backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,20 +52,25 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
           cache: 'gradle'
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+      - name: Compile Kotlin
+        run: ./gradlew compileKotlin compileJava -x test
+
+  build-web:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
-      - name: Make gradlew executable
-        run: chmod +x gradlew
-      - name: Compile Kotlin
-        run: ./gradlew compileKotlin compileJava -x test
+      - name: Install dependencies
+        run: cd web && npm ci
       - name: Build web
-        run: cd web && npm ci && npm run build
+        run: cd web && npm run build

--- a/cli.gradle
+++ b/cli.gradle
@@ -17,7 +17,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'kotlin'
 
 group = 'com.htmake'
-version = '4.0.3'
+version = '4.0.4'
 sourceCompatibility = '1.8'
 
 repositories {

--- a/simple-web-src/html/index.html
+++ b/simple-web-src/html/index.html
@@ -72,6 +72,7 @@
 </div>
 </div>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript" src="js/template.js"></script>
 <script type="text/javascript" src="js/template-data.js"></script>
 <script type="text/javascript" src="js/indexPage.js"></script>
 </body>

--- a/simple-web-src/html/reader.html
+++ b/simple-web-src/html/reader.html
@@ -249,6 +249,7 @@
 </div>
 </body>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript" src="js/template.js"></script>
 <script type="text/javascript" src="js/template-data.js"></script>
 <script type="text/javascript" src="js/readerPage.js"></script>
 </html>

--- a/simple-web-src/html/rss.html
+++ b/simple-web-src/html/rss.html
@@ -207,6 +207,7 @@
 </div>
 </div>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript" src="js/template.js"></script>
 <script type="text/javascript" src="js/template-data.js"></script>
 <script type="text/javascript" src="js/rssPage.js"></script>
 </body>

--- a/simple-web-src/html/search.html
+++ b/simple-web-src/html/search.html
@@ -69,6 +69,7 @@
 </div>
 </div>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript" src="js/template.js"></script>
 <script type="text/javascript" src="js/template-data.js"></script>
 <script type="text/javascript" src="js/searchPage.js"></script>
 </body>

--- a/simple-web-src/js/indexPage.js
+++ b/simple-web-src/js/indexPage.js
@@ -42,7 +42,7 @@ function onKeywordChange() {
  * Filter and sort books based on keyword input
  */
 function computeShowBookList() {
-    var keyword = .val().replace(/^\s+/g, "").replace(/\s+$/g, "");
+    var keyword = $("#keyword").val().replace(/^\s+/g, "").replace(/\s+$/g, "");
     var allBooks = bookListWatcher.getValue();
 
     // Sort by last read time (most recent first)
@@ -81,7 +81,7 @@ function computeShowBookList() {
  */
 function onPageInit() {
     bookApi.getBookshelf();
-    var container = ;
+    var container = $("#booklist");
 
     showBookListWatcher.onChange(function (books) {
         if (books && books.length > 0) {
@@ -90,9 +90,9 @@ function onPageInit() {
                 container.append(html);
                 pagination.init(".book-info", 0);
             });
-            .text("(" + books.length + ")");
+            $("#bookNum").text("(" + books.length + ")");
         } else {
-            .text("(0)");
+            $("#bookNum").text("(0)");
             container.html("");
             container.append(
                 "<div style='font-size: 1.6em;margin-top: 140px;text-align: center'>\n" +
@@ -174,8 +174,8 @@ function changeSource(bookUrl) {
             });
         } else {
             showTip(bookInfo.name + "(" + bookInfo.originName + ")", "关闭",
-                '<div style="text-align: center;">\n    <b onclick='loadMoreBookSource("' +
-                bookUrl + '")'> 加载更多书源</b>\n</div>');
+                '<div style="text-align: center;">\n    <b onclick=\'loadMoreBookSource("' +
+                bookUrl + "\")'>加载更多书源</b>\n</div>");
         }
     }, true);
 

--- a/simple-web-src/js/template-data.js
+++ b/simple-web-src/js/template-data.js
@@ -27,35 +27,35 @@
  * @param {string} extraClass - Optional CSS class to add
  */
 function showTip(title, closeText, bodyHtml, extraClass) {
-    .html(title);
-    .html(closeText);
-    .html(bodyHtml);
-    .css("display", "block");
+    $("#tipName").html(title);
+    $("#tipClose").html(closeText);
+    $("#tipBody").html(bodyHtml);
+    $("#tipBox").css("display", "block");
 
     // Remove previous extra class if any
-    var lastClass = .attr("data-lastclass");
+    var lastClass = $("#tipBox").attr("data-lastclass");
     if (lastClass) {
-        .removeClass(lastClass);
+        $("#tipBox").removeClass(lastClass);
     }
 
     // Add new extra class
     if (extraClass) {
-        .addClass(extraClass);
-        .attr("data-lastclass", extraClass);
+        $("#tipBox").addClass(extraClass);
+        $("#tipBox").attr("data-lastclass", extraClass);
     }
 
-    .attr("class", "dropdown-backdrop");
+    $("#dropdown-backdrop").attr("class", "dropdown-backdrop");
 }
 
 /**
  * Close the tip dialog
  */
 function closeTip() {
-    .attr("class", "");
-    .css("display", "none");
-    var lastClass = .attr("data-lastclass");
+    $("#dropdown-backdrop").attr("class", "");
+    $("#tipBox").css("display", "none");
+    var lastClass = $("#tipBox").attr("data-lastclass");
     if (lastClass) {
-        .removeClass(lastClass);
+        $("#tipBox").removeClass(lastClass);
     }
 }
 
@@ -67,8 +67,8 @@ function isHtml(str) {
 }
 
 // Tip dialog event handlers
-.click(function () { closeTip(); });
-.click(function (e) { closeTip(); });
+$("#tipClose").click(function () { closeTip(); });
+$("#dropdown-backdrop").click(function (e) { closeTip(); });
 
 // ============================================================
 // Section 2: Title Manager
@@ -277,22 +277,14 @@ function loadMoreBookSource(bookUrl) {
 
 function showLoginBox() {
     showTip("登录", "关闭",
-        "<div class='login-form'>
-" +
-        "    <form action='/login' onsubmit='return doLogin(this, true);'>
-" +
-        "       <label>用户名：<input type='text' name='username' /></label>
-" +
-        "       <label>密　码：<input type='text' name='password' /></label>
-" +
-        "       <label>邀请码：<input type='text' name='code' /></label>
-" +
-        "       <button type='submit' onclick='doLogin(this.parentNode, false)'>注册</button>
-" +
-        "       <button type='submit' onclick='doLogin(this.parentNode, true)'>登录</button>
-" +
-        "   </form>
-" +
+        "<div class='login-form'>\n" +
+        "    <form action='/login' onsubmit='return doLogin(this, true);'>\n" +
+        "       <label>用户名：<input type='text' name='username' /></label>\n" +
+        "       <label>密　码：<input type='text' name='password' /></label>\n" +
+        "       <label>邀请码：<input type='text' name='code' /></label>\n" +
+        "       <button type='submit' onclick='doLogin(this.parentNode, false)'>注册</button>\n" +
+        "       <button type='submit' onclick='doLogin(this.parentNode, true)'>登录</button>\n" +
+        "   </form>\n" +
         "</div>",
         "top-tip"
     );
@@ -367,9 +359,9 @@ window.darkThemeWatcher = new Watcher(false);
 var isBlack = $.cookie.get("black");
 if (isBlack && isBlack.toString() === "true") {
     window.darkThemeWatcher.update(true);
-    .attr("class", "dark-theme");
+    $("html").attr("class", "dark-theme");
 } else {
-    .attr("class", "white-theme");
+    $("html").attr("class", "white-theme");
 }
 
 // ============================================================
@@ -388,29 +380,18 @@ function showSettingBox() {
     }
 
     showTip("设置", "关闭",
-        "<div class='login-form'>
-" +
-        "    <form action='' onsubmit='return saveSetting(this);'>
-" +
-        "       <label>上边界：<input type='text' name='top' value='" + values[0] + "' /></label>
-" +
-        "       <label>下边界：<input type='text' name='bottom' value='" + values[1] + "' /></label>
-" +
-        "       <label>左边界：<input type='text' name='left' value='" + values[2] + "' /></label>
-" +
-        "       <label>右边界：<input type='text' name='right' value='" + values[3] + "' /></label>
-" +
-        "       <label>最大高度：<input type='text' name='maxHeight' value='" + values[4] + "' /></label>
-" +
-        "       <input id='hideSBInput' type='hidden' name='hideSB' value='" + values[5] + "' />
-" +
+        "<div class='login-form'>\n" +
+        "    <form action='' onsubmit='return saveSetting(this);'>\n" +
+        "       <label>上边界：<input type='text' name='top' value='" + values[0] + "' /></label>\n" +
+        "       <label>下边界：<input type='text' name='bottom' value='" + values[1] + "' /></label>\n" +
+        "       <label>左边界：<input type='text' name='left' value='" + values[2] + "' /></label>\n" +
+        "       <label>右边界：<input type='text' name='right' value='" + values[3] + "' /></label>\n" +
+        "       <label>最大高度：<input type='text' name='maxHeight' value='" + values[4] + "' /></label>\n" +
+        "       <input id='hideSBInput' type='hidden' name='hideSB' value='" + values[5] + "' />\n" +
         "       <label>隐藏滚动条：<span style='border: 1px solid #ddd;display: inline-block; padding: 3px 10px;' onclick='toggleScrollBarHidden(this)'>" +
-        (values[5] == 1 ? "已开启" : "已关闭") + "</span></label>
-" +
-        "       <button type='submit'>保存</button>
-" +
-        "   </form>
-" +
+        (values[5] == 1 ? "已开启" : "已关闭") + "</span></label>\n" +
+        "       <button type='submit'>保存</button>\n" +
+        "   </form>\n" +
         "</div>",
         "top-tip"
     );
@@ -423,13 +404,11 @@ function clearStorage() {
 }
 
 function showErrorMsg() {
-    showTip("温馨提示", "关闭", "<pre class='notice-info'>
-" + errorMsg + "</pre>");
+    showTip("温馨提示", "关闭", "<pre class='notice-info'>\n" + errorMsg + "</pre>");
 }
 
 function showNotice(msg) {
-    showTip("温馨提示", "关闭", "<pre class='notice-info'>
-" + msg + "</pre>");
+    showTip("温馨提示", "关闭", "<pre class='notice-info'>\n" + msg + "</pre>");
 }
 
 function isInteger(val) {
@@ -465,12 +444,12 @@ function saveSetting(form) {
 }
 
 function toggleScrollBarHidden(el) {
-    var val = .val();
+    var val = $("#hideSBInput").val();
     if (parseInt(val) === 1) {
-        .val("0");
+        $("#hideSBInput").val("0");
         el.innerText = "已关闭";
     } else {
-        .val("1");
+        $("#hideSBInput").val("1");
         el.innerText = "已开启";
     }
 }
@@ -479,7 +458,7 @@ function updatePagePosition() {
     var pageName = window.location.pathname.split("/");
     pageName = pageName[pageName.length - 1].replace(".html", "").toLowerCase();
     var saved = $.cookie.get(pageName + "bj");
-    var box = ;
+    var box = $("#pageBox");
 
     if (saved) {
         var vals = saved.split(",");
@@ -492,15 +471,15 @@ function updatePagePosition() {
             if (0 | vals[5]) {
                 var maxH = 0 | vals[4];
                 maxH = maxH > window.innerHeight / 2 ? maxH : window.innerHeight;
-                .css("max-height", maxH + "px");
-                .css("overflow", "hidden");
-                .css("max-height", maxH + "px");
-                .css("overflow", "hidden");
+                $("body").css("max-height", maxH + "px");
+                $("body").css("overflow", "hidden");
+                $("html").css("max-height", maxH + "px");
+                $("html").css("overflow", "hidden");
             } else {
-                if (.css("max-height")) .css("max-height", "none");
-                .css("overflow", "auto");
-                if (.css("max-height")) .css("max-height", "none");
-                .css("overflow", "auto");
+                if ($("body").css("max-height")) $("body").css("max-height", "none");
+                $("body").css("overflow", "auto");
+                if ($("html").css("max-height")) $("html").css("max-height", "none");
+                $("html").css("overflow", "auto");
             }
 
             if (window.reader && window.reader.viewDisplay) {
@@ -558,9 +537,9 @@ function debounce(fn, delay) {
  * Switch active menu tab
  */
 function chooseMenu(element, sectionId) {
-    .removeClass("choose");
-    .addClass("choose");
-    .addClass("choose");
+    $(".choose").removeClass("choose");
+    $(element).addClass("choose");
+    $("#" + sectionId).addClass("choose");
 }
 
 /**
@@ -675,8 +654,8 @@ var Pagination = function () {
     this.list = [];
     this.page = 1;
     this.pageCount = 1;
-    this.next = ;
-    this.before = ;
+    this.next = $("#next");
+    this.before = $("#before");
     this.pageIndexList = [];
     this.containerHeight = 0;
     this.onPageChange = null;
@@ -690,12 +669,12 @@ var Pagination = function () {
      * @param {number} initialPage - Starting page number
      */
     this.init = function (itemSelector, offset, containerSelector, onPageChange, initialPage) {
-        this.list = ;
+        this.list = $(itemSelector);
         if (!this.list || !this.list.length) return;
 
         this.onPageChange = onPageChange;
         containerSelector = containerSelector || ".right_t.flexone";
-        this.containerHeight = [0].offsetHeight - offset;
+        this.containerHeight = $(containerSelector)[0].offsetHeight - offset;
         this.computePage();
         this.page = initialPage || 1;
         this.display(this.page);
@@ -728,7 +707,7 @@ var Pagination = function () {
 
     /** Set pagination icon state */
     this.set = function (which, className) {
-        .removeClass(which + "Y").removeClass(which + "N").addClass(className);
+        $("#" + which + "_img").removeClass(which + "Y").removeClass(which + "N").addClass(className);
     };
 
     this.beforeClick = function () { this.display(this.page - 1); };
@@ -749,7 +728,7 @@ var Pagination = function () {
         var start = this.pageIndexList[this.page - 1];
         var end = this.pageIndexList[this.page];
         for (var i = start; i < end; i++) {
-            .css("display", "block");
+            $(this.list[i]).css("display", "block");
         }
 
         // Update pagination icons
@@ -763,5 +742,128 @@ var Pagination = function () {
         } else {
             this.set("before", "beforeY");
         }
+    };
+};
+
+// ============================================================
+// Section 14: Menu Class
+// ============================================================
+
+var Menu = function () {
+    /**
+     * Check whether dark theme is enabled (cookie "black" === "true")
+     */
+    function isBlackTheme() {
+        var black = $.cookie.get("black");
+        return !(!black || black.toString() !== "true");
+    }
+
+    /**
+     * Generate the dropdown menu items (小说书架/RSS阅读/小说搜索/页面设置/清除缓存/登录退出)
+     * @param {boolean} isLogin - Whether the user is currently logged in
+     */
+    this.generateMenu = function (isLogin) {
+        console.log("isLogin", isLogin);
+
+        // Current page name (index / rss / search / reader)
+        var pageName = window.location.pathname.split("/");
+        pageName = pageName[pageName.length - 1].replace(".html", "").toLowerCase();
+
+        var items = [
+            { key: "小说书架", url: "index" },
+            { key: "RSS阅读", url: "rss" },
+            { key: "小说搜索", url: "search" },
+            { key: "页面设置", url: "", action: "showSettingBox" },
+            { key: "清除缓存", url: "", action: "clearStorage" },
+            { key: isLogin ? "退出登录" : "登录", url: "", action: isLogin ? "doLogout" : "showLoginBox" }
+        ];
+
+        // Icon shown beside the current page's menu item
+        var currentPageIcon = isBlackTheme()
+            ? '<img alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAA39JREFUeF7tWu111DAQ3KkASggVEDoIHYQKIBUkVABUAKmAUAFQAVABSQfQQVLB8uY9mef4JGtXJ1v2+fQnPyJLmtHspw6y8YGN45cjAUcFbJyBowlsQQCq+k5EvgD4M8R70ApQ1VMR+Swi/EsC3myGAFW9FJFPA8DPhio4OAWo6tNw6+cR895RwUERECT/VUROEr7tAQAJ+j8OhgBVpX3T3lPjQUTOANweHAGqSuA7Dq4HNAqe/1+1AoK9U/Jn3pvv5q+WgEGIc8l+9SYQwP8QkUcOLcLCBYCbsWRvdQowOLsObxb86nyAA/xbAMMkKCqE1SjA4Ok7gNGUN2UGqyDAAf47gFgGmHQDiyfAAf4uJDr3ngp30QQ4wDPROQHgAr9YJ2hMcLqLTmZ5FiUsUgGOmyfGVwC+WcDG5iyOACf4DwDel4JfnAk4wbvC3eLDoBN8kcdfrAk4wdPpncYanCWm0NwHOMET40sAP0vALk4BqnolIh8dYPZ2esO9sgoIMZmtpOJQEwPoKGy6z91proXYUQICeNbd7KubykvLpqrKfJ2dHOv4G+zenenlNkgSMADfrXMD4CK36Nj/Hc2M/jIvhs3Mfc7Q/zZKQAJ89x1NgWpw34aqsl3929DJ6Z/RXNuXkLJDQAZ8twdby0xBd97aUocwrjv8fBK7H1WAqvKGaPO5QQUwJD3qs48QQJv31OqT2X2OgNwDQ/97kkCJjjYeVZXtKb7VecZkdm/xAR4SuN4VgOsYuoJwx2Wqx/sU82NRgLf62nFlOxGi0OP/AjD20OE4Un5qLg/wkkB/QL9wH5we/UnqoTJ2uqp5fh6+4WlMVUtIYK7AFNd7k3s1NyyAh3OsqTCLj+clGzi+mTzkxc6SJYAfBTlPSUJxU9NBcHSqiYAZSKha4npIMRMQSKBDo6N74tkkM/caAMviJsNFQCCBWSLNoQYJs2R7Y8y6CahMQjPpd6QUERBIYIhjr6B0VOnqlm6+NwGBBG/K3O3bzOu784Acw4W5/uwJTwpHsQn0F3Q2N5skPJMSEMzBkjLPnuvnFFxFAd0mhrphtjI3B7yKE4xtMkLCHQBLp8l69irzqiogmAJ/uharG5rH/Bhj1QlIkLCImD8bAQMSWD9Ue8ysovveIpMooOcUCf7c+pu92uAs601KgOUAreccCWh9A633Pyqg9Q203n/zCvgHXclLUIktpWUAAAAASUVORK5CYII=" style="width: 16px;height:16px;">'
+            : '<img alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAB9ElEQVR4nO2a4ZGCMBBGXwmUQAmUQAmWQAfawVmCHZgOvA7uOtAOzg60A+4Hw8jcAWYlycaQN7N/M98LYROikMlkMplM6nwApXYIDSrgDLSA0Y0Sni2d+LBKzUChKIAT/+VXsQoq4Idx+Ra460XzT8O0eC9faYXzzZGVyhfAFyuVH25xq5S/MS/f0vWF5Gh4Lr56+Z1SPq886/RJH3Zs5T+1AvrEVv5Cty0mha38ncTkbQ44Se/1tk++BTZKGb0hkd/rRPSHRN7oRPSHRD65ji+Rv5PY1ZZEvgVqlZSe2CGT32uELPCz1TTI5FWOuQWPS4fG4bgbZPJXFJreUL6vo4NxbS8zhhX8pDcm39eJ159GiVw++Lf9nHxfZ+Rbkc24Ubz3tiFvyJbm1K81Ub33IOvON+ya40Ewptp7P6QZCTRXW4djtUTykWOQhR7bIV7p+N9+dF7DIAt/5vHeFsz/UDlWUZ7zDfJJqLC/0RlWlJcbBd3np1RGWlHf6PqehLe41PQ5CXU4jWWUdE/LpfwhpIALKtxNwpU3WPpjuJqEOnBup9QskzehA/ugIeGub0uDfAKiPPAsQXK5GfWBZwkGu6Vf6sQLg2F+AvZawUJiGJe/KGYKytSRuVbMFJy/k2BU0yjRT0LyjW+OkkT/s5fJZDKZFPgF2+acfXQipdoAAAAASUVORK5CYII=" style="width: 16px;height:16px;">';
+
+        var menuEl = $("#Real_Menu");
+        var html = "";
+        menuEl.html("");
+        for (var i = 0; i < items.length; i++) {
+            html += '<li data-url="' + items[i].url + '" data-action="' + (items[i].action || "") + '">' +
+                '<div class="display_inline">' + (pageName === items[i].url.toLowerCase() ? currentPageIcon : "") + "</div>" +
+                items[i].key + "</li>";
+        }
+        menuEl.append(html);
+    };
+
+    /**
+     * Initialize the menu: bind dropdown toggle, backdrop, item clicks, theme and pagination buttons
+     */
+    this.initMenu = function () {
+        var self = this;
+
+        // Regenerate the menu when login state changes (immediately) and when theme changes
+        isLoginWatcher.onChange(function (isLogin) { self.generateMenu(isLogin); }, true);
+        window.darkThemeWatcher.onChange(function (dark) { self.generateMenu(dark); });
+
+        var menu = $("#Menu");
+
+        // Toggle dropdown open/close
+        $("#Menu_button").click(function (e) {
+            var dropup = $("#dropup2");
+            if (menu.attr("data-menu") === "false") {
+                dropup.addClass("open");
+                menu.attr("data-menu", "true");
+            } else {
+                dropup.removeClass("open");
+                menu.attr("data-menu", "false");
+            }
+            $("#dropdown-backdrop").attr("class", "dropdown-backdrop");
+        });
+
+        // Close dropdown when clicking the backdrop
+        $("#dropdown-backdrop").click(function (e) {
+            $("#dropup2").removeClass("open");
+            $("#tipBox").css("display", "none");
+            menu.attr("data-menu", "false");
+            $("#dropdown-backdrop").attr("class", "");
+        });
+
+        // Handle menu item clicks: navigate to page or run action
+        $("#Real_Menu").on("click", "li", function (e) {
+            var url = $(this).attr("data-url");
+            if (url) {
+                window.open("./" + url + ".html", "_self");
+            } else {
+                var action = $(this).attr("data-action");
+                console.log(action);
+                if (action) {
+                    $("#dropup2").removeClass("open");
+                    $("#tipBox").css("display", "none");
+                    menu.attr("data-menu", "false");
+                    $("#dropdown-backdrop").attr("class", "");
+                    window[action]();
+                }
+            }
+        });
+
+        // Dark / white theme toggle
+        $("#white").click(function () {
+            if (isBlackTheme()) {
+                $.cookie.set("black", "false");
+                $("html").attr("class", "white-theme");
+                window.darkThemeWatcher.update(false);
+            } else {
+                $.cookie.set("black", "true");
+                $("html").attr("class", "dark-theme");
+                window.darkThemeWatcher.update(true);
+            }
+        });
+
+        // Pagination buttons (only act when a global `pagination` exists, e.g. index/rss/search pages)
+        $("#before").click(function () {
+            if (window.pagination !== undefined) pagination.beforeClick();
+        });
+        $("#next").click(function () {
+            if (window.pagination !== undefined) pagination.nextClick();
+        });
     };
 };

--- a/src/main/resources/bookSourceDebug/index.html
+++ b/src/main/resources/bookSourceDebug/index.html
@@ -25,7 +25,7 @@
             <div>
                 <div>源类型　:</div>
                 <textarea rows="1" id="bookSourceType" class="base" title="bookSourceType"
-                          placeholder="&lt;必填&gt;0:文本 1:音频 2:图片 3:文件(只提供下载的网站)"></textarea>
+                          placeholder="&lt;必填&gt;0:文本 1:音频 2:图片 3:文件(只提供下载的网站) 4:视频"></textarea>
             </div>
             <div>
                 <div>源名称　:</div>

--- a/src/main/resources/bookSourceDebug/index.js
+++ b/src/main/resources/bookSourceDebug/index.js
@@ -25,6 +25,15 @@ function hashParam(key, val) {
     }
   }
 }
+function debounce(func, delay) {
+  let timerId;
+  return function(...args) {
+    clearTimeout(timerId);
+    timerId = setTimeout(() => {
+      func.apply(this, args);
+    }, delay);
+  };
+}
 // 创建源规则容器对象
 function Container() {
   let ruleJson = {};
@@ -35,7 +44,7 @@ function Container() {
   let contentJson = {};
 
   // 基本以及其他
-  $$(".rules .base").forEach((item) => (ruleJson[item.title] = ""));
+  $$(".rules .base").forEach(item => (ruleJson[item.title] = ""));
   ruleJson.lastUpdateTime = 0;
   ruleJson.customOrder = 0;
   ruleJson.weight = 0;
@@ -43,33 +52,33 @@ function Container() {
   ruleJson.enabledExplore = true;
 
   // 搜索规则
-  $$(".rules .ruleSearch").forEach((item) => (searchJson[item.title] = ""));
+  $$(".rules .ruleSearch").forEach(item => (searchJson[item.title] = ""));
   ruleJson.ruleSearch = searchJson;
 
   // 发现规则
-  $$(".rules .ruleExplore").forEach((item) => (exploreJson[item.title] = ""));
+  $$(".rules .ruleExplore").forEach(item => (exploreJson[item.title] = ""));
   ruleJson.ruleExplore = exploreJson;
 
   // 详情页规则
-  $$(".rules .ruleBookInfo").forEach((item) => (bookInfoJson[item.title] = ""));
+  $$(".rules .ruleBookInfo").forEach(item => (bookInfoJson[item.title] = ""));
   ruleJson.ruleBookInfo = bookInfoJson;
 
   // 目录规则
-  $$(".rules .ruleToc").forEach((item) => (tocJson[item.title] = ""));
+  $$(".rules .ruleToc").forEach(item => (tocJson[item.title] = ""));
   ruleJson.ruleToc = tocJson;
 
   // 正文规则
-  $$(".rules .ruleContent").forEach((item) => (contentJson[item.title] = ""));
+  $$(".rules .ruleContent").forEach(item => (contentJson[item.title] = ""));
   ruleJson.ruleContent = contentJson;
 
   return ruleJson;
 }
 // 选项卡Tab切换事件处理
 function showTab(tabName) {
-  $$(".tabtitle>*").forEach((node) => {
+  $$(".tabtitle>*").forEach(node => {
     node.className = node.className.replace(" this", "");
   });
-  $$(".tabbody>*").forEach((node) => {
+  $$(".tabbody>*").forEach(node => {
     node.className = node.className.replace(" this", "");
   });
   $(`.tabbody>.${$(`.tabtitle>*[name=${tabName}]`).className}`).className +=
@@ -85,11 +94,11 @@ function newRule(rule) {
 var RuleSources = [];
 if (localStorage.getItem("debug@BookSources")) {
   RuleSources = JSON.parse(localStorage.getItem("debug@BookSources"));
-  RuleSources.forEach((item) => ($("#RuleList").innerHTML += newRule(item)));
+  RuleSources.forEach(item => ($("#RuleList").innerHTML += newRule(item)));
 }
 // 页面加载完成事件
 window.onload = () => {
-  $$(".tabtitle>*").forEach((item) => {
+  $$(".tabtitle>*").forEach(item => {
     item.addEventListener("click", () => {
       showTab(item.innerHTML);
     });
@@ -102,8 +111,8 @@ function HttpGet(url) {
     mode: "cors",
     credentials: "include"
   })
-    .then((res) => res.json())
-    .catch((err) => console.error("Error:", err));
+    .then(res => res.json())
+    .catch(err => console.error("Error:", err));
 }
 // 提交数据
 function HttpPost(url, data) {
@@ -116,14 +125,14 @@ function HttpPost(url, data) {
       "Content-Type": "application/json;charset=utf-8"
     })
   })
-    .then((res) => res.json())
-    .catch((err) => console.error("Error:", err));
+    .then(res => res.json())
+    .catch(err => console.error("Error:", err));
 }
 // 将源表单转化为源对象
 function rule2json() {
   let RuleJSON = Container();
   // 转换base
-  Object.keys(RuleJSON).forEach((key) => {
+  Object.keys(RuleJSON).forEach(key => {
     if (!key.startsWith("rule")) {
       RuleJSON[key] = $("#" + key).value;
     }
@@ -131,7 +140,7 @@ function rule2json() {
 
   // 转换搜索规则
   let searchJson = {};
-  Object.keys(RuleJSON.ruleSearch).forEach((key) => {
+  Object.keys(RuleJSON.ruleSearch).forEach(key => {
     if ($("#" + "ruleSearch_" + key).value)
       searchJson[key] = $("#" + "ruleSearch_" + key).value;
   });
@@ -139,7 +148,7 @@ function rule2json() {
 
   // 转换发现规则
   let exploreJson = {};
-  Object.keys(RuleJSON.ruleExplore).forEach((key) => {
+  Object.keys(RuleJSON.ruleExplore).forEach(key => {
     if ($("#" + "ruleExplore_" + key).value)
       exploreJson[key] = $("#" + "ruleExplore_" + key).value;
   });
@@ -147,7 +156,7 @@ function rule2json() {
 
   // 转换详情页规则
   let bookInfoJson = {};
-  Object.keys(RuleJSON.ruleBookInfo).forEach((key) => {
+  Object.keys(RuleJSON.ruleBookInfo).forEach(key => {
     if ($("#" + "ruleBookInfo_" + key).value)
       bookInfoJson[key] = $("#" + "ruleBookInfo_" + key).value;
   });
@@ -155,7 +164,7 @@ function rule2json() {
 
   // 转换目录规则
   let tocJson = {};
-  Object.keys(RuleJSON.ruleToc).forEach((key) => {
+  Object.keys(RuleJSON.ruleToc).forEach(key => {
     if ($("#" + "ruleToc_" + key).value)
       tocJson[key] = $("#" + "ruleToc_" + key).value;
   });
@@ -163,7 +172,7 @@ function rule2json() {
 
   // 转换正文规则
   let contentJson = {};
-  Object.keys(RuleJSON.ruleContent).forEach((key) => {
+  Object.keys(RuleJSON.ruleContent).forEach(key => {
     if ($("#" + "ruleContent_" + key).value)
       contentJson[key] = $("#" + "ruleContent_" + key).value;
   });
@@ -191,7 +200,7 @@ function rule2json() {
 function json2rule(RuleEditor) {
   let RuleJSON = Container();
   // 转换base
-  Object.keys(RuleJSON).forEach((key) => {
+  Object.keys(RuleJSON).forEach(key => {
     if (!key.startsWith("rule")) {
       let val = RuleEditor[key];
       if (typeof val == "number") {
@@ -207,7 +216,7 @@ function json2rule(RuleEditor) {
   // 转换搜索规则
   if (RuleEditor.ruleSearch) {
     let searchJson = RuleEditor.ruleSearch;
-    Object.keys(RuleJSON.ruleSearch).forEach((key) => {
+    Object.keys(RuleJSON.ruleSearch).forEach(key => {
       $("#" + "ruleSearch_" + key).value = searchJson[key]
         ? searchJson[key]
         : "";
@@ -217,7 +226,7 @@ function json2rule(RuleEditor) {
   // 转换发现规则
   if (RuleEditor.ruleExplore) {
     let exploreJson = RuleEditor.ruleExplore;
-    Object.keys(RuleJSON.ruleExplore).forEach((key) => {
+    Object.keys(RuleJSON.ruleExplore).forEach(key => {
       $("#" + "ruleExplore_" + key).value = exploreJson[key]
         ? exploreJson[key]
         : "";
@@ -227,7 +236,7 @@ function json2rule(RuleEditor) {
   // 转换详情页规则
   if (RuleEditor.ruleBookInfo) {
     let bookInfoJson = RuleEditor.ruleBookInfo;
-    Object.keys(RuleJSON.ruleBookInfo).forEach((key) => {
+    Object.keys(RuleJSON.ruleBookInfo).forEach(key => {
       $("#" + "ruleBookInfo_" + key).value = bookInfoJson[key]
         ? bookInfoJson[key]
         : "";
@@ -237,7 +246,7 @@ function json2rule(RuleEditor) {
   // 转换目录规则
   if (RuleEditor.ruleToc) {
     let tocJson = RuleEditor.ruleToc;
-    Object.keys(RuleJSON.ruleToc).forEach((key) => {
+    Object.keys(RuleJSON.ruleToc).forEach(key => {
       $("#" + "ruleToc_" + key).value = tocJson[key] ? tocJson[key] : "";
     });
   }
@@ -245,7 +254,7 @@ function json2rule(RuleEditor) {
   // 转换正文规则
   if (RuleEditor.ruleContent) {
     let contentJson = RuleEditor.ruleContent;
-    Object.keys(RuleJSON.ruleContent).forEach((key) => {
+    Object.keys(RuleJSON.ruleContent).forEach(key => {
       $("#" + "ruleContent_" + key).value = contentJson[key]
         ? contentJson[key]
         : "";
@@ -288,10 +297,10 @@ function redo() {
 }
 function setRule(editRule) {
   let checkRule = RuleSources.find(
-    (x) => x.bookSourceUrl == editRule.bookSourceUrl
+    x => x.bookSourceUrl == editRule.bookSourceUrl
   );
   if ($(`input[id="${editRule.bookSourceUrl}"]`)) {
-    Object.keys(checkRule).forEach((key) => {
+    Object.keys(checkRule).forEach(key => {
       checkRule[key] = editRule[key];
     });
     $(
@@ -302,18 +311,18 @@ function setRule(editRule) {
     $("#RuleList").innerHTML += newRule(editRule);
   }
 }
-$$("input").forEach((item) => {
+$$("input").forEach(item => {
   item.addEventListener("change", () => {
     todo();
   });
 });
-$$("textarea").forEach((item) => {
+$$("textarea").forEach(item => {
   item.addEventListener("change", () => {
     todo();
   });
 });
 // 处理按钮点击事件
-$(".menu").addEventListener("click", (e) => {
+$(".menu").addEventListener("click", e => {
   let thisNode = e.target;
   thisNode =
     thisNode.parentNode.nodeName == "svg"
@@ -326,20 +335,20 @@ $(".menu").addEventListener("click", (e) => {
   thisNode.setAttribute("class", "busy");
   switch (thisNode.id) {
     case "push":
-      $$("#RuleList>label>div").forEach((item) => {
+      $$("#RuleList>label>div").forEach(item => {
         item.className = "";
       });
       (async () => {
         await HttpPost(`/saveBookSources`, RuleSources)
-          .then((json) => {
+          .then(json => {
             if (json.isSuccess) {
               let okData = json.data;
               if (Array.isArray(okData)) {
                 let failMsg = ``;
                 if (RuleSources.length > okData.length) {
-                  RuleSources.forEach((item) => {
+                  RuleSources.forEach(item => {
                     if (
-                      okData.find((x) => x.bookSourceUrl == item.bookSourceUrl)
+                      okData.find(x => x.bookSourceUrl == item.bookSourceUrl)
                     ) {
                       //
                     } else {
@@ -364,7 +373,7 @@ $(".menu").addEventListener("click", (e) => {
               alert(`批量推送源失败!\nErrorMsg: ${json.errorMsg}`);
             }
           })
-          .catch((err) => {
+          .catch(err => {
             alert(`批量推送源失败,无法连接到「Reader」!\n${err}`);
           });
         thisNode.setAttribute("class", "");
@@ -374,14 +383,14 @@ $(".menu").addEventListener("click", (e) => {
       showTab("源列表");
       (async () => {
         await HttpGet(`/getBookSources`)
-          .then((json) => {
+          .then(json => {
             if (json.isSuccess) {
               $("#RuleList").innerHTML = "";
               localStorage.setItem(
                 "debug@BookSources",
                 JSON.stringify((RuleSources = json.data))
               );
-              RuleSources.forEach((item) => {
+              RuleSources.forEach(item => {
                 $("#RuleList").innerHTML += newRule(item);
               });
               alert(`成功拉取 ${RuleSources.length} 条源`);
@@ -389,7 +398,7 @@ $(".menu").addEventListener("click", (e) => {
               alert(`批量拉取源失败!\nErrorMsg: ${json.errorMsg}`);
             }
           })
-          .catch((err) => {
+          .catch(err => {
             alert(`批量拉取源失败,无法连接到「Reader」!\n${err}`);
           });
         thisNode.setAttribute("class", "");
@@ -410,7 +419,7 @@ $(".menu").addEventListener("click", (e) => {
       $("#RuleJsonString").value = JSON.stringify(rule2json(), null, 4);
       break;
     case "initial":
-      $$(".rules textarea").forEach((item) => {
+      $$(".rules textarea").forEach(item => {
         item.value = "";
       });
       todo();
@@ -427,13 +436,23 @@ $(".menu").addEventListener("click", (e) => {
       //   .replace(/^.*?:/, "ws:")
       //   .replace(/\d+$/, port => parseInt(port) + 1);
       let DebugInfos = $("#DebugConsole");
+      let shouldScroll = false;
+      const debounceScrollIfNeeded = debounce(scrollIfNeeded, 100);
       function DebugPrint(msg) {
         DebugInfos.value += `\n${msg}`;
-        DebugInfos.scrollTop = DebugInfos.scrollHeight;
+        shouldScroll = true;
+        debounceScrollIfNeeded();
+        // DebugInfos.scrollTop = DebugInfos.scrollHeight;
+      }
+      function scrollIfNeeded() {
+        if (shouldScroll) {
+          DebugInfos.scrollTop = DebugInfos.scrollHeight;
+          shouldScroll = false;
+        }
       }
       let saveRule = [rule2json()];
       HttpPost(`/saveBookSources`, saveRule)
-        .then((sResult) => {
+        .then(sResult => {
           if (sResult.isSuccess) {
             let sKey = $("#DebugKey").value ? $("#DebugKey").value : "我的";
             $(
@@ -512,7 +531,7 @@ $(".menu").addEventListener("click", (e) => {
             // };
           } else throw `${sResult.errorMsg}`;
         })
-        .catch((err) => {
+        .catch(err => {
           DebugPrint(`调试过程意外中止，以下是详细错误信息:\n${err}`);
           thisNode.setAttribute("class", "");
         });
@@ -521,7 +540,7 @@ $(".menu").addEventListener("click", (e) => {
       (async () => {
         let saveRule = [rule2json()];
         await HttpPost(`/saveBookSource`, saveRule[0])
-          .then((json) => {
+          .then(json => {
             alert(
               json.isSuccess
                 ? `源《${saveRule[0].bookSourceName}》已成功保存到「Reader」`
@@ -529,7 +548,7 @@ $(".menu").addEventListener("click", (e) => {
             );
             setRule(saveRule[0]);
           })
-          .catch((err) => {
+          .catch(err => {
             alert(`保存源失败,无法连接到「Reader」!\n${err}`);
           });
         thisNode.setAttribute("class", "");
@@ -541,14 +560,14 @@ $(".menu").addEventListener("click", (e) => {
     thisNode.setAttribute("class", "");
   }, 500);
 });
-$("#DebugKey").addEventListener("keydown", (e) => {
+$("#DebugKey").addEventListener("keydown", e => {
   if (e.keyCode == 13) {
     let clickEvent = document.createEvent("MouseEvents");
     clickEvent.initEvent("click", true, false);
     $("#debug").dispatchEvent(clickEvent);
   }
 });
-$("#Filter").addEventListener("keydown", (e) => {
+$("#Filter").addEventListener("keydown", e => {
   if (e.keyCode == 13) {
     let cashList = [];
     $("#RuleList").innerHTML = "";
@@ -557,7 +576,7 @@ $("#Filter").addEventListener("keydown", (e) => {
       cashList = RuleSources;
     } else {
       let patt = new RegExp(sKey);
-      RuleSources.forEach((source) => {
+      RuleSources.forEach(source => {
         if (
           patt.test(source.bookSourceUrl) ||
           patt.test(source.bookSourceName) ||
@@ -567,18 +586,18 @@ $("#Filter").addEventListener("keydown", (e) => {
         }
       });
     }
-    cashList.forEach((source) => {
+    cashList.forEach(source => {
       $("#RuleList").innerHTML += newRule(source);
     });
   }
 });
 
 // 列表规则更改事件
-$("#RuleList").addEventListener("click", (e) => {
+$("#RuleList").addEventListener("click", e => {
   let editRule = null;
   if (e.target && e.target.getAttribute("name") == "rule") {
     editRule = rule2json();
-    json2rule(RuleSources.find((x) => x.bookSourceUrl == e.target.id));
+    json2rule(RuleSources.find(x => x.bookSourceUrl == e.target.id));
   } else return;
   if (editRule.bookSourceUrl == "") return;
   if (editRule.bookSourceName == "")
@@ -590,7 +609,7 @@ $("#RuleList").addEventListener("click", (e) => {
   localStorage.setItem("debug@BookSources", JSON.stringify(RuleSources));
 });
 // 处理列表按钮事件
-$(".tab3>.titlebar").addEventListener("click", (e) => {
+$(".tab3>.titlebar").addEventListener("click", e => {
   let thisNode = e.target;
   if (thisNode.nodeName != "BUTTON") return;
   switch (thisNode.id) {
@@ -620,12 +639,12 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
                     JSON.stringify((RuleSources = newSources))
                   );
                   $("#RuleList").innerHTML = "";
-                  RuleSources.forEach((item) => {
+                  RuleSources.forEach(item => {
                     $("#RuleList").innerHTML += newRule(item);
                   });
                 } else {
                   newSources = newSources.filter(
-                    (item) =>
+                    item =>
                       !JSON.stringify(RuleSources).includes(item.bookSourceUrl)
                   );
                   RuleSources.push(...newSources);
@@ -633,7 +652,7 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
                     "debug@BookSources",
                     JSON.stringify(RuleSources)
                   );
-                  newSources.forEach((item) => {
+                  newSources.forEach(item => {
                     $("#RuleList").innerHTML += newRule(item);
                   });
                 }
@@ -655,7 +674,7 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
         .replace(/.*?\s(\d+)\s(\d+)\s(\d+:\d+:\d+).*/, "$2$1$3")
         .replace(/:/g, "")}.json`;
       let myBlob = new Blob([JSON.stringify(RuleSources, null, 4)], {
-        type: "application/json",
+        type: "application/json"
       });
       fileExport.href = window.URL.createObjectURL(myBlob);
       fileExport.click();
@@ -669,13 +688,13 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
       if (confirm(`确定要删除选定源吗?\n(同时删除APP内源)`)) {
         let selectRuleUrl = selectRule.id;
         let deleteSources = RuleSources.filter(
-          (item) => item.bookSourceUrl == selectRuleUrl
+          item => item.bookSourceUrl == selectRuleUrl
         ); // 提取待删除的源
         let laveSources = RuleSources.filter(
-          (item) => !(item.bookSourceUrl == selectRuleUrl)
+          item => !(item.bookSourceUrl == selectRuleUrl)
         ); // 提取待留下的源
         HttpPost(`/deleteBookSources`, deleteSources)
-          .then((json) => {
+          .then(json => {
             if (json.isSuccess) {
               let selectNode = document.getElementById(selectRuleUrl)
                 .parentNode;
@@ -685,7 +704,7 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
                 JSON.stringify((RuleSources = laveSources))
               );
               if ($("#bookSourceUrl").value == selectRuleUrl) {
-                $$(".rules textarea").forEach((item) => {
+                $$(".rules textarea").forEach(item => {
                   item.value = "";
                 });
                 todo();
@@ -694,7 +713,7 @@ $(".tab3>.titlebar").addEventListener("click", (e) => {
               console.log(`以上源已删除!`);
             }
           })
-          .catch((err) => {
+          .catch(err => {
             alert(`删除源失败,无法连接到「Reader」!\n${err}`);
           });
       }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
         "sortablejs": "^1.15.0",
         "stylus": "^0.54.7",
         "stylus-loader": "^3.0.2",
-        "vue": "^2.6.10",
+        "vue": "2.7.16",
         "vue-lazyload": "^1.3.3",
         "vue-router": "^3.1.3",
         "vuex": "^3.1.1"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reader",
-  "version": "2.5.4",
+  "version": "4.0.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -21,7 +21,7 @@
     "sortablejs": "^1.15.0",
     "stylus": "^0.54.7",
     "stylus-loader": "^3.0.2",
-    "vue": "^2.6.10",
+    "vue": "2.7.16",
     "vue-lazyload": "^1.3.3",
     "vue-router": "^3.1.3",
     "vuex": "^3.1.1"

--- a/web/src/components/BookSource.vue
+++ b/web/src/components/BookSource.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="popup-wrapper" :style="popupTheme">
     <div class="title-zone">
-      <div class="title">来源({{ bookSource.length }})</div>
-      <div :class="{ 'title-btn': true, loading: loadingMore }">
+      <div class="title">来源({{ showBookSourceList.length }})</div>
+      <div
+        class="title-btn"
+        v-show="!isSearching"
+        :class="{ loading: loading }"
+      >
         <el-select
           size="mini"
           v-model="bookSourceGroup"
@@ -18,6 +22,9 @@
           >
           </el-option>
         </el-select>
+        <span class="span-btn" @click="expand = !expand">{{
+          expand ? "收起" : "展开"
+        }}</span>
         <span :class="{ loading: loading }" @click="refresh">
           <i class="el-icon-loading" v-if="loading"></i>
           {{ loading ? "刷新中..." : "刷新" }}
@@ -29,17 +36,39 @@
           <i class="el-icon-loading" v-if="loadingMore"></i>
           {{ loadingMore ? "加载中..." : "加载更多" }}
         </span>
+        <span class="span-btn" @click="isSearching = !isSearching">{{
+          isSearching ? "取消" : "搜索"
+        }}</span>
+      </div>
+      <div
+        class="title-btn"
+        v-show="isSearching"
+        :class="{ loading: loadingMore }"
+      >
+        <el-input
+          class="booksource-filter-input"
+          size="mini"
+          placeholder="搜索书源"
+          v-model="searchKeyword"
+        ></el-input>
+        <span class="span-btn" @click="isSearching = !isSearching">{{
+          isSearching ? "取消" : "搜索"
+        }}</span>
       </div>
     </div>
     <div
       class="data-wrapper"
       ref="sourceList"
-      :class="{ night: $store.getters.isNight, day: !$store.getters.isNight }"
+      :class="{
+        night: $store.getters.isNight,
+        day: !$store.getters.isNight,
+        expand: expand
+      }"
     >
       <div class="source-list">
         <div
           class="source-item"
-          v-for="(searchBook, index) in bookSource"
+          v-for="(searchBook, index) in showBookSourceList"
           :class="{ selected: isSelected(searchBook) }"
           :key="index"
           @click="changeBookSource(searchBook)"
@@ -76,7 +105,10 @@ export default {
       bookSourceGroup: "",
       bookSourceGroupIndexMap: {},
       loading: false,
-      loadingMore: false
+      expand: false,
+      loadingMore: false,
+      isSearching: false,
+      searchKeyword: ""
     };
   },
   props: ["visible"],
@@ -97,6 +129,13 @@ export default {
     },
     readingBook() {
       return this.$store.getters.readingBook || {};
+    },
+    showBookSourceList() {
+      return this.isSearching && this.searchKeyword
+        ? this.bookSource.filter(t =>
+            (t.latestChapterTitle || "").includes(this.searchKeyword)
+          )
+        : this.bookSource;
     }
   },
   mounted() {},
@@ -379,6 +418,9 @@ export default {
     .booksource-group-select {
       width: 140px;
     }
+    .booksource-filter-input {
+      width: 200px;
+    }
     .source-count {
       display: inline-block;
       color: #606266;
@@ -394,6 +436,10 @@ export default {
   .data-wrapper {
     height: 300px;
     overflow: auto;
+
+    &.expand {
+      height: 85vh;
+    }
 
     .source-list {
       .source-item {

--- a/web/src/components/ReadSettings.vue
+++ b/web/src/components/ReadSettings.vue
@@ -9,9 +9,9 @@
       <div class="title-btn" @click="resetConfig">重置</div>
       <div class="title-btn" @click="restoreConfig">同步</div>
       <div class="title-btn" @click="backupConfig">保存</div>
-      <div class="title-btn" @click="toggleNotAutoSync">{{
-        notAutoSync ? "自动同步" : "取消自动同步"
-      }}</div>
+      <div class="title-btn" @click="toggleNotAutoSync">
+        {{ notAutoSync ? "自动同步" : "取消自动同步" }}
+      </div>
     </div>
     <div class="setting-list">
       <ul>
@@ -490,6 +490,22 @@
           </div>
         </li>
         <li>
+          <span class="setting-item-title">Epub解析</span>
+          <div class="selection-zone">
+            <span
+              class="span-item"
+              v-for="(mode, index) in epubModes"
+              :key="index"
+              :class="{ selected: config.epubMode == mode }"
+              @click="setEpubMode(mode)"
+              >{{ mode }}</span
+            >
+            <span class="small-tip"
+              >❗️解析可能导致显示问题，但是翻页性能较好，样式支持更多，也支持简繁切换。</span
+            >
+          </div>
+        </li>
+        <li>
           <span class="setting-item-title">请求超时</span>
           <div class="resize">
             <span class="less" @click="decConfig('chapterRequestTimeout')"
@@ -613,6 +629,7 @@ export default {
       configDefaultTypeList: ["白天默认", "黑夜默认"],
       autoReadingMethods: ["像素滚动", "段落滚动"],
       chineseFonts: ["简体", "繁体", "原文"],
+      epubModes: ["iframe", "解析"],
       quickKeyModes: ["默认", "自定义"],
       quickKeyOps: [
         "上一页",
@@ -750,6 +767,10 @@ export default {
       this.$emit("readMethodChange");
       this.config = { ...this.config, readMethod };
     },
+    setEpubMode(epubMode) {
+      this.$emit("epubModeChange");
+      this.config = { ...this.config, epubMode };
+    },
     setQuickKeyMode(quickKeyMode) {
       this.config = { ...this.config, quickKeyMode };
     },
@@ -768,7 +789,10 @@ export default {
       }
     },
     restoreConfig() {
-      if (this.$root.$children[0] && this.$root.$children[0].restoreUserConfig) {
+      if (
+        this.$root.$children[0] &&
+        this.$root.$children[0].restoreUserConfig
+      ) {
         this.$root.$children[0].restoreUserConfig();
       }
     },
@@ -1296,6 +1320,10 @@ export default {
           cursor: pointer;
           color: #ed4259;
         }
+      }
+
+      .small-tip {
+        font-size: 13px;
       }
     }
   }

--- a/web/src/plugins/config.js
+++ b/web/src/plugins/config.js
@@ -40,6 +40,7 @@ const defaultDayConfig = {
   autoReadingPixel: 1,
   autoReadingLineTime: 1000,
   pageMode: "自适应",
+  selectionAction: "操作弹窗",
   topPadding: 0,
   bottomPadding: 0,
   horizontalPadding: 0,
@@ -57,8 +58,7 @@ const defaultDayConfig = {
     PageDown: "上一页",
     Home: "首页",
     End: "尾页"
-  },
-  selectionAction: "操作弹窗"
+  }
 };
 const defaultNightConfig = {
   configDefaultType: "黑夜默认",
@@ -83,6 +83,7 @@ const defaultNightConfig = {
   autoReadingPixel: 1,
   autoReadingLineTime: 1000,
   pageMode: "自适应",
+  selectionAction: "操作弹窗",
   topPadding: 0,
   bottomPadding: 0,
   horizontalPadding: 0,
@@ -100,8 +101,7 @@ const defaultNightConfig = {
     PageDown: "上一页",
     Home: "首页",
     End: "尾页"
-  },
-  selectionAction: "操作弹窗"
+  }
 };
 const settings = {
   shelfConfig: {

--- a/web/src/plugins/vuex.js
+++ b/web/src/plugins/vuex.js
@@ -48,7 +48,7 @@ export default new Vuex.Store({
     userList: [].concat(defaultNS),
     userNS: "default",
     showManagerMode: false,
-    version: "v4.0.3",
+    version: "v4.0.4",
     filterRules: [],
     speechVoiceConfig: { ...settings.speechVoiceConfig },
     safeArea: {


### PR DESCRIPTION
## 概述

对齐 reader-pro-3.2.14 JAR 的 web / simple-web 实现，修复源码层损坏与缺失功能，并发布 v4.0.4。

## 变更内容

### 1. 编译产物对齐 JAR（`src/main/resources/`）
- 补齐缺失的 **14 张 web/bg 背景图**（JAR 有但仓库缺失，且被 `reader.js` 引用，会导致 404）
- 补齐 **4 个 simple-web 字体**（书体坊郭小语钢笔楷体/字体管家楷体/方正宋刻本秀楷简/杨任东竹石体）
- 对齐 `web/`、`simple-web/` 编译产物（js/css/html/service-worker/precache-manifest 等），与 JAR **字节级一致**
- 修正重复的 `bookSourceDebug` 目录，与 `web/bookSourceDebug/`（JAR 版本）保持一致

### 2. simple-web 源码修复（`simple-web-src/`）
反向工程源码存在系统性损坏，修复后与 JAR 编译产物对齐：
- **template-data.js**：恢复被剥落的 `$()` 接收对象、修复 `\n` 转义导致的语法错误、修复 `Pagination.display` 的裸 `.removeClass()`
- **新增 `Menu` 类**：小说书架/RSS阅读/小说搜索/页面设置/清除缓存/登录·退出，生成菜单 HTML 与 JAR **逐字节一致**（含 base64 明暗主题图标）
- **indexPage.js**：修复引号转义与未闭合字符串
- **4 个 html** 补加载 `js/template.js`（原缺失导致 `renderTmpl` 抛 `template is not defined`）

### 3. web 前端功能补齐
- **Epub解析设置**（ReadSettings.vue）：`epubModes: ["iframe", "解析"]` + 提示文案，对齐 JAR
- **换源弹窗搜索过滤框**（BookSource.vue）：`searchKeyword`/`isSearching`/`showBookSourceList` + 展开/收起
- **config.js**：`selectionAction` 键序对齐 JAR 默认配置
- **依赖**：vue 2.6.10 → 2.7.16（兼容已存在的 dplayer 视频书源渲染）

### 4. 版本号对齐
- `cli.gradle`: 4.0.3 → **4.0.4**
- `web/package.json`: 2.5.4 → **4.0.4**（与 releases 对齐）
- `web/src/plugins/vuex.js` 前端版本显示: v4.0.3 → **v4.0.4**

## 验证
- `node --check` 全部 8 个 simple-web JS 通过
- Menu 生成 HTML 与 JAR 逐字节一致（DOM stub 测试）
- simple-web 4 页面冒烟测试无 ReferenceError
- 编译产物与 JAR 字节级一致（web 62/62、simple-web 24/24、bookSourceDebug 6/6）
- PR 检查将运行 `compileKotlin` + `compileJava` + web 构建

## 遗留
- `requireTmpl` 请求 `./assets/template/*.tmpl`，源码模板位于 `templates/`，部署依赖预编译的 `template-dcac4aae98.js`（与 JAR 行为一致，属构建环节，未改动）
