### PR TITLE
ci(docker): 分层缓存 npm/gradle 依赖、串行发布，根治构建慢与 429 限流

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,3 +44,7 @@ out
 /bin
 /file-uploads
 node_modules
+
+# git 与 CI 元数据（减小 build context）
+.git
+.github

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -1,19 +1,27 @@
+# ---- Build web frontend (npm deps layer cached) ----
 FROM node:16-alpine AS build-web
-ADD . /app
 WORKDIR /app/web
-RUN npm ci && npm run build
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
 
-# Build jar
+# ---- Build jar (gradle deps layer cached) ----
 FROM gradle:7-jdk8 AS build-env
 ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3"
-ADD --chown=gradle:gradle . /app
 WORKDIR /app
+# 先复制构建脚本并预下载依赖，该层可被 docker 层缓存复用
+COPY --chown=gradle:gradle cli.gradle gradle ./
+RUN gradle -b cli.gradle dependencies --no-daemon || true
+# 复制源码与前端产物
+ADD --chown=gradle:gradle . /app
 COPY --from=build-web /app/web/dist /app/src/main/resources/web
 RUN \
     rm src/main/java/com/htmake/reader/ReaderUIApplication.kt; \
-    gradle -b cli.gradle assemble --info; \
+    gradle -b cli.gradle assemble --no-daemon; \
     mv ./build/libs/*.jar ./build/libs/reader.jar
 
+# ---- Runtime ----
 FROM amazoncorretto:8u442-alpine3.21-jre
 RUN \
     apk add --no-cache ca-certificates tini tzdata; \


### PR DESCRIPTION
## 背景
v4.0.4 发布时 master push 与 tag push 两个 workflow **并发**构建，且 Dockerfile 无分层缓存导致 gradle/npm 依赖**每次全量下载**：
- release job 因 Maven Central **429 Too Many Requests** 限流失败
- 镜像构建耗时 30+ 分钟

## 变更
1. **Dockerfile.source 分层缓存**：先 COPY 依赖清单并预下载（npm ci / gradle dependencies），依赖层可被 buildx gha 缓存跨 run 复用
2. **.dockerignore**：排除 .git/.github，减小 build context
3. **docker-publish.yml**：concurrency 串行化发布（master 与 tag 不再并发），根治限流

## 验证
- 本次仅改 CI/Docker 配置，不触发代码构建（paths-filter 按需运行）
- 合并后重跑 v4.0.4 发布验证镜像构建