### PR TITLE
ci(docker): 仅在打 tag 时发布，一次构建同时打 vX.Y.Z/latest/master 标签

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Publish Docker Image
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*'
   workflow_dispatch:
@@ -66,10 +64,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=master,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=sha
 
       - name: Build and push


### PR DESCRIPTION
## 问题
每次发版触发两遍 Publish Docker Image：
1. PR 合并到 master → push master 事件 → 构建 master 镜像
2. 打 tag → push tag 事件 → 构建 vX.Y.Z/latest 镜像 + 发布 Release

内容重复、浪费 CI，且曾因并发触发 Maven Central 429 限流。

## 变更
- 移除 `on.push.branches: [master]`：master 分支不再触发构建/发布（PR 检查已覆盖代码验证，test 由 pull-request.yml 负责）
- metadata tags 移除 `event=branch`，新增 `raw=master`（tag 触发时同时打 master 标签）：
  - `v4.0.x`（ref=tag）、`4.0.x`（semver）、`latest`、`master`、`sha-xxx`
- 效果：一次发版 = 一次构建，master 镜像仍可用（指向最新 tag）