### PR TITLE
fix(storage): 本地书章节不存在

### DIFF
--- a/scripts/fix-local-book-chapter-namespace.py
+++ b/scripts/fix-local-book-chapter-namespace.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""修复本地书章节命名空间错位（BUGFIX: 本地书章节不存在）。
+
+背景: v6.0.45 及更早版本多个章节写入路径未填充 book_chapters.user_namespace，
+落库为 'default'；而读取路径严格按用户命名空间过滤。secure 模式下非 default
+账号导入的本地书因此读不到正文（TOC 能列出，正文报「本地书章节不存在」）。
+本脚本修复**既有数据**——把 user_namespace='default' 但归属书属于非 default
+命名空间的章节行，修正为书所属命名空间。
+
+用法:
+  python3 scripts/fix-local-book-chapter-namespace.py [--db path/to/reader.db]
+       [--dry-run] [--yes]
+
+环境: 需先停止 reader-dev 服务（SQLite 写锁/备份一致性），建议先备份库再执行。
+输出: 打印修正的章节行数（--dry-run 只统计不修改，exit 0）。
+注意: 幂等——已修正的行不会再次匹配；default 命名空间书、非 default 已正确
+      归属的章节均不受影响。
+"""
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DB = ROOT / "storage" / "reader.db"
+
+# 相关子查询消歧：共享 book_url 归属多个命名空间时，确定性取字典序最小 ns。
+# EXISTS 限定只处理“归属书存在非 default 命名空间”的章节，default 书不受影响。
+FIX_SQL = """
+UPDATE book_chapters
+SET user_namespace = (
+    SELECT user_namespace FROM books
+    WHERE books.book_url = book_chapters.book_url
+    ORDER BY user_namespace LIMIT 1
+)
+WHERE book_chapters.user_namespace = 'default'
+  AND EXISTS (
+    SELECT 1 FROM books
+    WHERE books.book_url = book_chapters.book_url
+      AND books.user_namespace <> 'default'
+  )
+"""
+
+COUNT_SQL = """
+SELECT COUNT(*) FROM book_chapters bc
+WHERE bc.user_namespace = 'default'
+  AND EXISTS (
+    SELECT 1 FROM books b
+    WHERE b.book_url = bc.book_url AND b.user_namespace <> 'default'
+  )
+"""
+
+# 受影响章节按归属命名空间分组（dry-run 明细）
+GROUP_SQL = """
+SELECT b.user_namespace, COUNT(*)
+FROM book_chapters bc
+JOIN books b ON b.book_url = bc.book_url
+WHERE bc.user_namespace = 'default'
+  AND b.user_namespace <> 'default'
+GROUP BY b.user_namespace
+ORDER BY b.user_namespace
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="修复本地书章节 user_namespace 错位（先备份库再执行）"
+    )
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB,
+                        help=f"reader.db 路径（默认 {DEFAULT_DB}）")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="只统计待修复章节，不修改数据")
+    parser.add_argument("--yes", action="store_true",
+                        help="跳过执行前确认（建议仍先手动备份）")
+    args = parser.parse_args()
+
+    db_path = args.db.expanduser()
+    if not db_path.exists():
+        print(f"错误: 数据库不存在 {db_path}", file=sys.stderr)
+        return 1
+
+    conn = sqlite3.connect(str(db_path), timeout=30)
+    try:
+        pending = conn.execute(COUNT_SQL).fetchone()[0]
+        print(f"待修复章节: {pending} 行（user_namespace='default' 但归属非 default 书）")
+        if pending == 0:
+            print("无需修复（数据库已正确或本 bug 不影响本库）")
+            return 0
+
+        if args.dry_run:
+            print("\n受影响章节按归属命名空间分组（dry-run，未修改）:")
+            for ns, cnt in conn.execute(GROUP_SQL).fetchall():
+                print(f"  {ns}: {cnt} 行")
+            print("dry-run 完成，未修改任何数据")
+            return 0
+
+        if not args.yes:
+            answer = input(
+                f"将修改 {db_path} 中 {pending} 行章节——"
+                "执行前请确认已备份该库。继续? [y/N] "
+            )
+            if answer.strip().lower() not in ("y", "yes"):
+                print("已取消，未修改任何数据")
+                return 0
+
+        rows = conn.execute(FIX_SQL).rowcount
+        conn.commit()
+        print(f"已修正 {rows} 行章节的 user_namespace")
+        print("提示: 重新启动 reader-dev 后，既有本地书正文即可直接读取，无需重新导入")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -4980,7 +4980,7 @@ async fn refresh_local_book(
         .iter()
         .map(|c| (c.title.clone(), c.content.clone()))
         .collect();
-    if let Err(e) = state.storage.save_chapters(&url, &pairs).await {
+    if let Err(e) = state.storage.save_chapters(&namespace, &url, &pairs).await {
         tracing::error!("refreshLocalBook 章节入库失败: {e}");
         return Json(ReturnData::err("刷新失败"));
     }
@@ -11427,6 +11427,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "https://book.com/a",
                 &[("第一章".to_string(), "正文A".to_string())],
             )
@@ -11435,6 +11436,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "https://book.com/b",
                 &[("第一章".to_string(), "正文B".to_string())],
             )
@@ -11497,6 +11499,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "https://book.com/a",
                 &[("第一章".to_string(), "正文A2".to_string())],
             )
@@ -11535,6 +11538,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "https://book.com/b",
                 &[("第一章".to_string(), "正文B".to_string())],
             )
@@ -11587,7 +11591,7 @@ mod tests {
         let local_url = "storage/data/default/本地书.txt";
         state
             .storage
-            .save_chapters(local_url, &[("第一章".to_string(), "本地正文".to_string())])
+            .save_chapters("default", local_url, &[("第一章".to_string(), "本地正文".to_string())])
             .await
             .unwrap();
         state
@@ -11645,6 +11649,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "https://book.com/a",
                 &[
                     ("第一章".to_string(), "正文一二三".to_string()),
@@ -14864,6 +14869,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://book1",
                 &[
                     ("第一章".to_string(), "正文一甲乙".to_string()),
@@ -15023,6 +15029,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://book1",
                 &[
                     (
@@ -16007,6 +16014,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://abc",
                 &[
                     ("第一章".to_string(), "第一段内容".to_string()),
@@ -16575,6 +16583,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://exp1",
                 &[
                     ("第一章".to_string(), "正文一 <甲> & 乙。".to_string()),
@@ -16754,6 +16763,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://expfont",
                 &[("第一章".to_string(), "正文一。".to_string())],
             )
@@ -17119,6 +17129,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://gbk1",
                 &[("第一章".to_string(), "正文😀结束。".to_string())],
             )
@@ -17188,6 +17199,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 "local://gbk2",
                 &[("第一章".to_string(), "纯中文正文。".to_string())],
             )
@@ -17531,6 +17543,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 book_url,
                 &[
                     ("第一章".to_string(), "正文一".to_string()),
@@ -17758,6 +17771,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 book_url,
                 &[
                     ("第一章".to_string(), "正文一".to_string()),
@@ -17875,6 +17889,7 @@ mod tests {
         state
             .storage
             .save_chapters(
+                "default",
                 book_url,
                 &[
                     ("第一章".to_string(), "正文一".to_string()),
@@ -18333,7 +18348,7 @@ mod tests {
         }
         state
             .storage
-            .save_chapters("https://b.com/1", &[("第一章".into(), "正文".into())])
+            .save_chapters("default", "https://b.com/1", &[("第一章".into(), "正文".into())])
             .await
             .unwrap();
 

--- a/src/service/local_sync.rs
+++ b/src/service/local_sync.rs
@@ -913,6 +913,7 @@ mod tests {
             .unwrap();
         storage
             .save_chapters(
+                "default",
                 &book_url,
                 &[
                     ("第一章".to_string(), "正文一。".to_string()),
@@ -984,7 +985,7 @@ mod tests {
                 .await
                 .unwrap();
             storage
-                .save_chapters(&book_url, &[("第一章".to_string(), "正文。".to_string())])
+                .save_chapters("default", &book_url, &[("第一章".to_string(), "正文。".to_string())])
                 .await
                 .unwrap();
         }

--- a/src/storage/migrate.rs
+++ b/src/storage/migrate.rs
@@ -487,12 +487,13 @@ async fn migrate_chapter_cache(
                         continue;
                     };
                     sqlx::query(
-                        "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content) VALUES (?1, ?2, ?3, ?4)",
+                        "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content, user_namespace) VALUES (?1, ?2, ?3, ?4, ?5)",
                     )
                     .bind(&book_url)
                     .bind(idx)
                     .bind(&title)
                     .bind(&content)
+                    .bind(ns)
                     .execute(&mut *tx)
                     .await?;
                     inserted += 1;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2023,16 +2023,22 @@ impl Storage {
     }
 
     /// 保存章节（本地书）
-    pub async fn save_chapters(&self, book_url: &str, chapters: &[(String, String)]) -> Result<()> {
+    pub async fn save_chapters(
+        &self,
+        ns: &str,
+        book_url: &str,
+        chapters: &[(String, String)],
+    ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         for (i, (title, content)) in chapters.iter().enumerate() {
             sqlx::query(
-                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content) VALUES (?1, ?2, ?3, ?4)",
+                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content, user_namespace) VALUES (?1, ?2, ?3, ?4, ?5)",
             )
             .bind(book_url)
             .bind(i as i64)
             .bind(title)
             .bind(content)
+            .bind(ns)
             .execute(&mut *tx)
             .await?;
         }
@@ -3656,12 +3662,13 @@ impl Storage {
             .collect();
         for (i, (title, content)) in chapters.iter().enumerate() {
             sqlx::query(
-                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content) VALUES (?1,?2,?3,?4)",
+                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content, user_namespace) VALUES (?1,?2,?3,?4,?5)",
             )
             .bind(&info.book_url)
             .bind(i as i64)
             .bind(title)
             .bind(content)
+            .bind(ns)
             .execute(&mut *tx)
             .await?;
         }
@@ -3696,19 +3703,21 @@ impl Storage {
             return Ok(false);
         }
         let mut tx = self.pool.begin().await?;
-        // 覆盖式重建章节（重复迁移幂等）
-        sqlx::query("DELETE FROM book_chapters WHERE book_url = ?1")
+        // 覆盖式重建章节（重复迁移幂等）；仅删当前命名空间章节——防共享 book_url 误删他用户章节
+        sqlx::query("DELETE FROM book_chapters WHERE book_url = ?1 AND user_namespace = ?2")
             .bind(book_url)
+            .bind(ns)
             .execute(&mut *tx)
             .await?;
         for (i, (title, content)) in chapters.iter().enumerate() {
             sqlx::query(
-                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content) VALUES (?1,?2,?3,?4)",
+                "INSERT OR REPLACE INTO book_chapters (book_url, chapter_index, title, content, user_namespace) VALUES (?1,?2,?3,?4,?5)",
             )
             .bind(book_url)
             .bind(i as i64)
             .bind(title)
             .bind(content)
+            .bind(ns)
             .execute(&mut *tx)
             .await?;
         }
@@ -3833,12 +3842,13 @@ impl Storage {
         .await?;
         for (i, (title, content)) in chapters.iter().enumerate() {
             sqlx::query(
-                "INSERT INTO book_chapters (book_url, chapter_index, title, content) VALUES (?1, ?2, ?3, ?4)",
+                "INSERT INTO book_chapters (book_url, chapter_index, title, content, user_namespace) VALUES (?1, ?2, ?3, ?4, ?5)",
             )
             .bind(book_url)
             .bind(i as i64)
             .bind(title)
             .bind(content)
+            .bind(ns)
             .execute(&mut *tx)
             .await?;
         }
@@ -6519,6 +6529,84 @@ mod tests {
         cleanup(storage, "locbooktype").await;
     }
 
+    /// BUGFIX 回归：非 default 命名空间导入本地书，章节写入带 user_namespace，
+    /// TOC 与正文（get_chapter_content 按 ns 过滤）均可读；他用户隔离不可读。
+    #[tokio::test]
+    async fn test_save_local_book_non_default_ns_chapters_readable() {
+        let storage = test_storage("locbookns").await;
+        let imported = crate::service::local_book::ImportedBook {
+            meta: Default::default(),
+            chapters: vec![
+                crate::service::local_book::Chapter {
+                    title: "第一章".into(),
+                    content: "正文一".into(),
+                },
+                crate::service::local_book::Chapter {
+                    title: "第二章".into(),
+                    content: "正文二".into(),
+                },
+            ],
+            cover: None,
+            format: "epub".into(),
+        };
+        let info = crate::model::book_chapter::BookInfo {
+            book_url: "local://userabook".into(),
+            name: "用户A的书".into(),
+            origin: "local".into(),
+            ..Default::default()
+        };
+        storage
+            .save_local_book("userA", &info, &imported)
+            .await
+            .unwrap();
+        // 章节按 userA ns 落库
+        assert_eq!(storage.count_chapters("userA", "local://userabook").await.unwrap(), 2);
+        // TOC 可列出
+        let toc = storage
+            .list_chapters_with_word_count("local://userabook")
+            .await
+            .unwrap();
+        assert_eq!(toc.len(), 2);
+        assert_eq!(toc[0].1, "第一章");
+        assert_eq!(toc[0].2, 3, "正文一 3 字符");
+        // 正文按 userA ns 可读
+        assert_eq!(
+            storage
+                .get_chapter_content("userA", "local://userabook", 0)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("正文一")
+        );
+        assert_eq!(
+            storage
+                .get_chapter_content("userA", "local://userabook", 1)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("正文二")
+        );
+        // 跨用户隔离：他人命名空间读不到
+        assert_eq!(
+            storage
+                .get_chapter_content("userB", "local://userabook", 0)
+                .await
+                .unwrap(),
+            None,
+            "他用户命名空间不应读到章节正文"
+        );
+        assert_eq!(
+            storage
+                .get_chapter_content("default", "local://userabook", 0)
+                .await
+                .unwrap(),
+            None,
+            "default 命名空间不应读到 userA 的章节（回归：旧缺陷写 default 导致可读）"
+        );
+
+        cleanup(storage, "locbookns").await;
+    }
+
     /// F-10：目录缓存写入 → 命中 → 过期未命中
     #[tokio::test]
     async fn test_toc_cache_roundtrip() {
@@ -8637,6 +8725,7 @@ mod tests {
             .unwrap();
         storage
             .save_chapters(
+                "default",
                 "local://book1",
                 &[
                     ("第一章".to_string(), "正文一甲乙丙丁".to_string()),
@@ -8685,6 +8774,7 @@ mod tests {
             .unwrap();
         storage
             .save_chapters(
+                "default",
                 "local://book1",
                 &[("第四章".to_string(), "正文四".to_string())],
             )
@@ -8713,6 +8803,7 @@ mod tests {
         // 书 A：本地书章节 + 书源书正文缓存（md5 键）混合
         storage
             .save_chapters(
+                "default",
                 "https://book.com/a",
                 &[
                     ("第一章".to_string(), "正文一二三四五".to_string()),
@@ -8733,6 +8824,7 @@ mod tests {
             .unwrap();
         storage
             .save_chapters(
+                "default",
                 "https://book.com/b",
                 &[("第一章".to_string(), "另一本".to_string())],
             )
@@ -8823,6 +8915,7 @@ mod tests {
         // WAL 副作用文件存在（reader.db-wal 惰性创建——写一次触发）
         storage
             .save_chapters(
+                "default",
                 "local://waltest",
                 &[("第一章".to_string(), "正文".to_string())],
             )
@@ -8895,6 +8988,7 @@ mod tests {
         let storage = test_storage("search").await;
         storage
             .save_chapters(
+                "default",
                 "local://book1",
                 &[
                     ("第一章".to_string(), "这是第一章的正文，关键词出现了。".to_string()),
@@ -8906,6 +9000,7 @@ mod tests {
             .unwrap();
         storage
             .save_chapters(
+                "default",
                 "local://book2",
                 &[("第一章".to_string(), "另一本书里的关键词。".to_string())],
             )
@@ -8953,6 +9048,7 @@ mod tests {
         // 大小写不敏感（ASCII）
         storage
             .save_chapters(
+                "default",
                 "local://book3",
                 &[("Ch1".to_string(), "Hello World here".to_string())],
             )
@@ -8975,6 +9071,7 @@ mod tests {
         // %/_ 作为字面量转义（不当作 LIKE 通配符）
         storage
             .save_chapters(
+                "default",
                 "local://book4",
                 &[
                     ("C1".to_string(), "进度5_0%完成。".to_string()),
@@ -9390,7 +9487,7 @@ mod tests {
 
         // 与本地书顺序索引共存：哈希键域（~2^60）不重叠 0..n
         storage
-            .save_chapters(book_url, &[("本地1".to_string(), "本地内容1".to_string())])
+            .save_chapters("default", book_url, &[("本地1".to_string(), "本地内容1".to_string())])
             .await
             .unwrap();
         assert_eq!(
@@ -10225,7 +10322,7 @@ mod tests {
             .await
             .unwrap();
         storage
-            .save_chapters(url, &[("第一章".into(), "正文一".into())])
+            .save_chapters("default", url, &[("第一章".into(), "正文一".into())])
             .await
             .unwrap();
         storage
@@ -10290,7 +10387,7 @@ mod tests {
             .await
             .unwrap();
         storage
-            .save_chapters(url, &[("第一章".into(), "正文".into())])
+            .save_chapters("default", url, &[("第一章".into(), "正文".into())])
             .await
             .unwrap();
         storage.cache_toc("default", url, url, "[]").await.unwrap();
@@ -10340,7 +10437,7 @@ mod tests {
             .await
             .unwrap();
         storage
-            .save_chapters(url, &[("第一章".into(), "正文".into())])
+            .save_chapters("default", url, &[("第一章".into(), "正文".into())])
             .await
             .unwrap();
 
@@ -10374,7 +10471,7 @@ mod tests {
             .await
             .unwrap();
         storage
-            .save_chapters(url, &[("旧章".into(), "旧正文".into())])
+            .save_chapters("default", url, &[("旧章".into(), "旧正文".into())])
             .await
             .unwrap();
 


### PR DESCRIPTION
## 问题
book_chapters 表带 user_namespace TEXT NOT NULL DEFAULT 'default' 列，但多个章节写入路径未填充该列，落库为 'default'；而读取路径 get_chapter_content 严格按实际用户命名空间过滤。
secure 模式下命名空间为用户名（非 default），于是：
- books 行正确写入 user_namespace='用户名' → 书能显示、TOC 能列出（列表不按 ns 过滤）
- 章节正文写入成 'default' → 按 '用户名' 查询读不到 → {"isSuccess":false,"errorMsg":"本地书章节不存在"}
即写入/读取 key 不一致，属跨用户隔离缺陷。仅 default 命名空间的书碰巧正常；任何非 default 账号导入的本地书都会复现。现有测试几乎全用 'default'，故未暴露。

## 修复
章节写入路径补齐 user_namespace（新写入即正确，向后不再产生脏数据）：
- save_local_book：本地书导入（books + 章节）INSERT 补 user_namespace
- migrate_loc_book：legacy loc_book 迁移章节 INSERT 补列；其 DELETE 补 user_namespace 过滤（防共享 book_url 误删他用户章节）
- replace_chapters：local_sync 重扫章节 INSERT 补列
- save_chapters：增加 ns 参数，章节 INSERT 补列；更新 refreshLocalBook 生产调用
- migrate.rs 章节缓存迁移器写入补列

## 既有数据修复脚本
本BUGFIX不做自动数据修复。受影响的既有库由用户手动执行幂等修复脚本：
#### 1. 停止 reader-dev，备份库
cp storage/reader.db storage/reader.db.bak
### 2. 预览将修正的行数（不修改）
python3 scripts/fix-local-book-chapter-namespace.py --dry-run
### 3. 执行修复
python3 scripts/fix-local-book-chapter-namespace.py
### 4. 重启 reader-dev，旧本地书正文即可直接读取，无需重新导入
脚本把 user_namespace='default' 但归属书属于非 default 命名空间的章节，修正为书所属命名空间；幂等，default 命名空间书不受影响。

### 测试
新增回归测试：非 default 用户（userA）经 save_local_book 导入本地书 → TOC 与正文（get_chapter_content）均可读；userB / default 命名空间读不到（隔离正确）。现有 default 测试保持全绿。